### PR TITLE
correct Python version requirement & Yahoo API setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Model Context Protocol (MCP) server for Yahoo Fantasy Football integration wit
 
 ### Prerequisites
 
-- Python 3.9+
+- Python 3.11+
 - Claude Desktop
 - Yahoo Fantasy Sports account
 - Yahoo Developer App credentials

--- a/YAHOO_SETUP.md
+++ b/YAHOO_SETUP.md
@@ -15,7 +15,7 @@ You'll need the following credentials:
 
 1. **Navigate to Yahoo Developer Portal**
    - Go to https://developer.yahoo.com/
-   - Click "My Apps" in the top menu
+   - Click "Apps" in the top menu
    - Sign in with your Yahoo account (the same one you use for Fantasy Sports)
 
 2. **Verify Your Account**
@@ -42,19 +42,19 @@ You'll need the following credentials:
    - This is just for reference, not actually used
 
    ### Redirect URI(s)
-   - Enter: `http://localhost:8000/callback`
+   - Enter: `https://localhost:8000/callback`
    - ⚠️ **CRITICAL**: 
      - Must be HTTPS not HTTP for localhost
      - Must NOT have trailing slash
      - Must match EXACTLY in your code
 
+   ### OAuth Client Type
+   - Pick Confidential Client - Choose for traditional apps.
+
    ### API Permissions
    - Find "Fantasy Sports" in the list
    - Click the checkbox for **"Read"** permission
    - ✅ Only select Read (not Read/Write)
-
-   ### OAuth Client Type
-   - Pick Confidential Client - Choose for traditional apps.
 
 4. **Create the App**
    - Click "Create App" button


### PR DESCRIPTION
I observed that the mcp library requires Python 3.10, and the pegged version of the "click" python library requires Python 3.11.  So I had to upgrade to get it working (no big deal - it works!).  I updated the README to reflect this.

Also updated a couple of bits from the Yahoo instructions to more closely match the UI I see.

HTH! We'll see how it goes as we get into the season :)