### PR TITLE
Distinguish Yahoo provisioning 401s from expired-token 401s

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -30,17 +30,24 @@ pip install -r requirements.txt
 
 ## Step 3: Yahoo API Setup
 
-### 3.1 Create a Yahoo Developer App
+### 3.1 Create a Yahoo Developer App — and apply for Fantasy Sports API access
 
-1. Go to https://developer.yahoo.com/apps/
-2. Click "Create an App"
-3. Fill in the application details:
+> **⚠️ Yahoo no longer self-serve provisions the Fantasy Sports API.** The app
+> creation form no longer offers a "Fantasy Sports" permission (only OpenID
+> Connect and TW Auction). Creating an app gives you valid OAuth credentials
+> that are **not** entitled to the Fantasy API — every call will return `401`
+> with `oauth_problem="additional_authorization_required"` until Yahoo approves
+> your access application (step 3 below). Refreshing tokens or recreating the
+> app will not fix this. Yahoo has also de-provisioned some previously working
+> apps, so long-time users may need to apply as well.
+
+1. Go to https://developer.yahoo.com/apps/ and click "Create an App":
    - **Application Name**: Fantasy Football MCP (or your choice)
    - **Application Type**: Web Application
    - **Redirect URI(s)**: `oob` (for out-of-band OAuth flow - you'll copy the verification code manually)
-   - **API Permissions**: Fantasy Sports (Read)
-4. Click "Create App"
-5. Save your **Client ID (Consumer Key)** and **Client Secret (Consumer Secret)**
+2. Click "Create App" and save your **Client ID (Consumer Key)** and **Client Secret (Consumer Secret)**.
+3. **Apply for Fantasy Sports API access** at https://sports.yahoo.com/developer/access/ — include the Client ID from step 2 so the approval is attached to the app you already created. Approval is a manual human review with no published turnaround time; the API stays 401 until it lands.
+4. Note that Yahoo currently grants **read-only** access (`fspt-r`) — write access is not available, so nothing in this server can or does write through the API.
 
 **Note**: The authentication scripts use the "oob" (out-of-band) redirect URI, which means you'll copy the verification code from the browser and paste it into the terminal. This is simpler than setting up a callback server.
 

--- a/fastmcp_server.py
+++ b/fastmcp_server.py
@@ -69,7 +69,10 @@ _TOOL_PROMPTS: Dict[str, str] = {
         "Build optimal lineup from your roster using strategy-based optimization and positional constraints."
     ),
     "ff_refresh_token": (
-        "🔑 Refresh Yahoo OAuth token. " "NO parameters. Use when API returns 401 errors."
+        "🔑 Refresh Yahoo OAuth token. "
+        "NO parameters. Use for expired-token 401s (oauth_problem=token_rejected). "
+        "Does NOT help with additional_authorization_required - that means the Yahoo app "
+        "lacks Fantasy Sports API provisioning; see INSTALLATION.md."
     ),
     "ff_get_api_status": (
         "📊 Check API health and rate limits. "
@@ -523,7 +526,11 @@ async def ff_build_lineup(
     description=(
         "🔑 Refresh Yahoo OAuth token. "
         "NO parameters required. "
-        "Use when API calls return 401 authentication errors."
+        "Use when API calls return 401 errors from an expired token "
+        "(oauth_problem=token_rejected). A 401 with "
+        "additional_authorization_required is a provisioning problem the "
+        "refresh cannot fix - the Yahoo app needs Fantasy Sports API access "
+        "approved at https://sports.yahoo.com/developer/access/."
     ),
     meta=_tool_meta("ff_refresh_token"),
 )

--- a/src/api/yahoo_client.py
+++ b/src/api/yahoo_client.py
@@ -11,6 +11,19 @@ from src.api.yahoo_utils import rate_limiter, response_cache
 _YAHOO_ACCESS_TOKEN = os.getenv("YAHOO_ACCESS_TOKEN")
 YAHOO_API_BASE = "https://fantasysports.yahooapis.com/fantasy/v2"
 
+# Yahoo's 401s carry an oauth_problem that distinguishes recoverable from
+# unrecoverable auth failures. additional_authorization_required means the
+# token is valid but the app itself is not entitled to the Fantasy Sports
+# API — refreshing can never help. See issue #18.
+NOT_PROVISIONED_ERROR = (
+    "Your Yahoo app is not provisioned for the Fantasy Sports API "
+    '(oauth_problem="additional_authorization_required"). This is not a '
+    "token problem - refreshing will not help. Yahoo no longer self-serve "
+    "provisions Fantasy Sports API access; apply at "
+    "https://sports.yahoo.com/developer/access/ and include your existing "
+    "Client ID so approval is attached to the app you already have."
+)
+
 
 def get_access_token() -> str:
     """Get the current access token."""
@@ -65,18 +78,22 @@ async def yahoo_api_call(
                 if use_cache:
                     await response_cache.set(endpoint, data)
                 return data
-            elif response.status == 401 and retry_on_auth_fail:
-                # Token expired, try to refresh
-                refresh_result = await refresh_yahoo_token()
-                if refresh_result.get("status") == "success":
-                    # Token refreshed, retry the API call with new token
-                    return await yahoo_api_call(
-                        endpoint, retry_on_auth_fail=False, use_cache=use_cache
-                    )
-                else:
-                    # Refresh failed, raise the original error
-                    text = await response.text()
+            elif response.status == 401:
+                text = await response.text()
+                # A provisioning failure is not recoverable by refresh: the
+                # token authenticates fine, the APP lacks Fantasy API access.
+                if "additional_authorization_required" in text:
+                    raise Exception(NOT_PROVISIONED_ERROR)
+                if retry_on_auth_fail:
+                    # token_rejected / expired token - refreshing helps here
+                    refresh_result = await refresh_yahoo_token()
+                    if refresh_result.get("status") == "success":
+                        # Token refreshed, retry the API call with new token
+                        return await yahoo_api_call(
+                            endpoint, retry_on_auth_fail=False, use_cache=use_cache
+                        )
                     raise Exception(f"Yahoo API auth failed and token refresh failed: {text[:200]}")
+                raise Exception(f"Yahoo API error 401 after token refresh: {text[:200]}")
             else:
                 text = await response.text()
                 raise Exception(f"Yahoo API error {response.status}: {text[:200]}")

--- a/utils/setup_yahoo_auth.py
+++ b/utils/setup_yahoo_auth.py
@@ -42,6 +42,45 @@ print(f"   Client ID: {CLIENT_ID[:30]}...")
 print(f"   Client Secret: {CLIENT_SECRET[:10]}...")
 print()
 
+def preflight_fantasy_access(access_token):
+    """Verify the app is actually provisioned for the Fantasy Sports API.
+
+    A successful token exchange does NOT mean Fantasy API access: Yahoo no
+    longer self-serve provisions the Fantasy Sports API, so an app can hold
+    perfectly valid tokens that every fantasysports.yahooapis.com call rejects
+    with oauth_problem="additional_authorization_required". Catch that here,
+    at setup time, instead of letting the first real tool call fail later.
+    """
+    print()
+    print("🔎 Preflight: checking Fantasy Sports API provisioning...")
+    try:
+        response = requests.get(
+            "https://fantasysports.yahooapis.com/fantasy/v2/game/nfl?format=json",
+            headers={"Authorization": f"Bearer {access_token}", "Accept": "application/json"},
+            timeout=30,
+        )
+    except requests.exceptions.RequestException as e:
+        print(f"⚠️  Preflight request failed to send: {e}")
+        print("   Could not determine provisioning status.")
+        return False
+
+    if response.status_code == 200:
+        print("✅ Fantasy Sports API access confirmed - your app is provisioned.")
+        return True
+    if response.status_code == 401 and "additional_authorization_required" in response.text:
+        print("❌ Your tokens are VALID, but your Yahoo app is NOT provisioned for")
+        print("   the Fantasy Sports API. This is not a token problem - re-running")
+        print("   this setup, refreshing tokens, or recreating the app will not fix it.")
+        print()
+        print("   Apply for access at: https://sports.yahoo.com/developer/access/")
+        print("   Include your existing Client ID so approval attaches to this app.")
+        print("   Approval is a manual review with no published turnaround time;")
+        print("   every Fantasy API call will keep returning 401 until it lands.")
+        return False
+    print(f"⚠️  Preflight returned status {response.status_code}: {response.text[:200]}")
+    return False
+
+
 def exchange_verification_code_for_tokens(verification_code, client_id, client_secret):
     """Exchange Yahoo OAuth verification code for access and refresh tokens."""
     token_url = "https://api.login.yahoo.com/oauth2/get_token"
@@ -301,23 +340,10 @@ def manual_oauth_flow(client_id, client_secret):
     
     print("   The MCP server can now use this token!")
     print()
-    
-    # Test the token by making a simple API call
-    print("Testing connection...")
-    try:
-        test_url = "https://fantasysports.yahooapis.com/fantasy/v2/users;use_login=1/games"
-        headers = {
-            "Authorization": f"Bearer {token_data.get('access_token')}"
-        }
-        response = requests.get(test_url, headers=headers)
-        if response.status_code == 200:
-            print("✅ Connection test successful!")
-        else:
-            print(f"⚠️  Connection test returned status {response.status_code}")
-    except Exception as e:
-        print(f"⚠️  Connection test failed: {e}")
-        print("   But token was saved successfully.")
-    
+
+    # Verify the app can actually reach the Fantasy API (provisioning check)
+    preflight_fantasy_access(token_data.get('access_token'))
+
     return True
 
 # Method 1: Using yfpy (Recommended)
@@ -392,10 +418,12 @@ try:
                     update_env_file_with_tokens(access_token, refresh_token, ENV_FILE_PATH)
                     # Also update MCP config files
                     update_mcp_configs(access_token, refresh_token)
+                    # Verify the app can actually reach the Fantasy API
+                    preflight_fantasy_access(access_token)
                 else:
                     print("⚠️  Could not extract tokens from token_data to update .env")
                     print(f"   Token data keys: {list(token_data.keys())}")
-                
+
                 print("   The MCP server can now use this token!")
             
         except Exception as e:


### PR DESCRIPTION
Implements all three fixes from #18 (fixes #18).

## What changed

**1. `yahoo_api_call` inspects the 401 body before refreshing** (`src/api/yahoo_client.py`)
A 401 containing `oauth_problem="additional_authorization_required"` now fails immediately with an actionable message (apply at https://sports.yahoo.com/developer/access/ with your existing Client ID) instead of taking the refresh-and-retry path that can never succeed. `token_rejected`/expired-token 401s still refresh and retry exactly as before. The `ff_refresh_token` tool descriptions in `fastmcp_server.py` no longer advertise refresh as the remedy for every 401.

**2. `INSTALLATION.md` step 3.1 rewritten**
The "Fantasy Sports (Read)" API-permission checkbox no longer exists in Yahoo's app form. The docs now lead with a warning that app creation is necessary but not sufficient, add the manual access-application step (a human review with no published SLA), note that Yahoo has de-provisioned some previously working apps, and state that read-only `fspt-r` is the only available scope.

**3. Provisioning preflight in `utils/setup_yahoo_auth.py`**
After the token exchange, both auth flows now call `/fantasy/v2/game/nfl` and report provisioning status explicitly — a valid-token-but-unprovisioned app is caught at setup time with the application URL, instead of the first real tool call failing hours later.

## Verification

- Mocked-response behavioral tests: provisioning 401 → immediate actionable error with zero refresh attempts; `token_rejected` 401 → refresh → retry → success; `token_rejected` + failed refresh → combined error. All pass.
- `tests/unit/test_api_client.py`: 3 failed / 9 passed both before and after the change — the 3 failures are pre-existing in `TestRefreshYahooToken` and unrelated (that function is untouched).

Thanks @dmackerman for an exceptionally precise report — the `oauth_problem` taxonomy and the three-token reproduction made this a straightforward fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk auth error-handling and documentation; expired-token refresh behavior is preserved; only adds an early exit path for a specific 401 body.
> 
> **Overview**
> Yahoo Fantasy API **401** responses are now split by `oauth_problem`: **`additional_authorization_required`** (app not provisioned) fails immediately with guidance to apply at sports.yahoo.com/developer/access, while **expired-token** 401s still trigger refresh-and-retry in `yahoo_api_call`.
> 
> **INSTALLATION.md** no longer references the removed Fantasy Sports permission checkbox; it documents manual API access approval, read-only scope, and that token refresh cannot fix provisioning.
> 
> **`setup_yahoo_auth.py`** runs a post-auth preflight against `/fantasy/v2/game/nfl` so unprovisioned apps are caught at setup. **`ff_refresh_token`** tool text in `fastmcp_server.py` clarifies refresh only helps `token_rejected`, not provisioning errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4785048a4c0220f4632af156d2d0a03eff39c9d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->