### PR TITLE
Reframe README as single-user app with ChatGPT app store readiness section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Fantasy Football MCP Server
 
-A Model Context Protocol (MCP) server for Yahoo Fantasy Football. It exposes league, roster, matchup, waiver-wire, draft, and lineup-analysis data to AI clients while keeping the underlying fantasy data source separate from the model.
+A personal, single-user Model Context Protocol (MCP) server for Yahoo Fantasy Football. It exposes league, roster, matchup, waiver-wire, draft, and lineup-analysis data to AI clients while keeping the underlying fantasy data source separate from the model.
 
 ## Current status
 
-The project is usable today as a local or single-user MCP server. Yahoo Fantasy Sports API access now requires manual approval from Yahoo, and Yahoo currently provides read access only. Write actions such as adding/dropping players or changing lineups are therefore not part of the supported public tool surface.
+This project is built and run as a **single-user app**: you supply your own Yahoo developer credentials and tokens, and the server serves your leagues to your MCP client. It is not intended to be deployed by someone else as a shared, multi-user service.
 
-The repository also contains the first stage of multi-user hardening: Yahoo credentials can be bound to an individual async request instead of relying exclusively on process-wide environment variables, and Yahoo response-cache keys are isolated by user in request-scoped mode.
+That said, the codebase deliberately includes groundwork for a future multi-user version — request-scoped Yahoo credentials and per-user cache isolation — so that when the app is submitted to the ChatGPT app store, the core plumbing is already in place. See [ChatGPT app store readiness](#chatgpt-app-store-readiness) below. You do not need any of that to run the app yourself.
 
-A production public ChatGPT app still needs an application-level identity layer and encrypted per-user Yahoo token storage before it should be exposed to multiple users.
+Note that Yahoo Fantasy Sports API access now requires manual approval from Yahoo, and Yahoo currently provides read access only. Write actions such as adding/dropping players or changing lineups are therefore not part of the tool surface.
 
 ## Core capabilities
 
@@ -40,7 +40,7 @@ The main FastMCP server currently exposes:
 - `ff_analyze_draft_state`
 - `ff_analyze_reddit_sentiment`
 
-The server also contains maintenance tools used for local operation and troubleshooting. A public consumer deployment should expose only the user-facing read/analysis tools it actually needs.
+The server also contains maintenance tools used for local operation and troubleshooting.
 
 ## Installation
 
@@ -58,11 +58,9 @@ Creating a Yahoo developer application is no longer sufficient by itself to use 
 
 Yahoo's current access model is read-only. This project therefore treats league-management recommendations separately from transaction execution.
 
-## Authentication modes
+## Authentication
 
-### Local / legacy single-user mode
-
-For local development, the server can continue to read these environment variables:
+The server reads your Yahoo credentials from environment variables:
 
 ```env
 YAHOO_CLIENT_ID=...
@@ -72,29 +70,7 @@ YAHOO_REFRESH_TOKEN=...
 YAHOO_GUID=...
 ```
 
-### Request-scoped / multi-user foundation
-
-Production code can bind one Yahoo credential set to the current async request:
-
-```python
-from src.api.yahoo_credentials import YahooCredentials, use_yahoo_credentials
-
-credentials = YahooCredentials(
-    access_token=user_access_token,
-    refresh_token=user_refresh_token,
-    client_id=app_client_id,
-    client_secret=app_client_secret,
-    user_id=user_id,
-)
-
-with use_yahoo_credentials(credentials):
-    # Yahoo calls made in this context use only this user's credentials.
-    ...
-```
-
-Token refreshes in request-scoped mode remain inside that request context rather than mutating process-wide environment variables. Cached Yahoo responses are also namespaced per user.
-
-For a public deployment, the values passed into `YahooCredentials` should come from an authenticated application session and an encrypted server-side credential store. Do not accept raw Yahoo tokens directly from model tool arguments.
+This single-user mode is the supported way to run the app.
 
 ## Running the MCP server
 
@@ -131,15 +107,41 @@ Credential-isolation tests cover request-scoped token handling and user-namespac
 
 ## Security notes
 
+Even as a single-user app, keep credentials out of the repository:
+
 - Never commit Yahoo access or refresh tokens.
-- Never bake user tokens into a container image.
-- Do not use one process-wide Yahoo token for a multi-user deployment.
-- Namespace caches by authenticated user.
-- Store production refresh tokens encrypted at rest.
-- Keep Yahoo client secrets server-side.
+- Never bake your tokens into a container image.
+- Keep your Yahoo client secret server-side.
 - Rotate any credential that has ever been committed to a public Git history.
 
 If a secret was previously committed, deleting the current file is not sufficient by itself: revoke/rotate the credential and, when appropriate, rewrite the repository history.
+
+## ChatGPT app store readiness
+
+This app runs single-user today, but the code is structured so it can become a public ChatGPT app later without a rewrite. The multi-user groundwork already in the codebase includes:
+
+- **Request-scoped credentials** — `src/api/yahoo_credentials.py` can bind one Yahoo credential set to the current async request instead of relying on process-wide environment variables:
+
+```python
+from src.api.yahoo_credentials import YahooCredentials, use_yahoo_credentials
+
+credentials = YahooCredentials(
+    access_token=user_access_token,
+    refresh_token=user_refresh_token,
+    client_id=app_client_id,
+    client_secret=app_client_secret,
+    user_id=user_id,
+)
+
+with use_yahoo_credentials(credentials):
+    # Yahoo calls made in this context use only this user's credentials.
+    ...
+```
+
+- **Isolated token refresh** — token refreshes in request-scoped mode stay inside that request context rather than mutating process-wide environment variables.
+- **Per-user cache namespacing** — cached Yahoo responses are keyed by user in request-scoped mode.
+
+What remains before an app store submission is application infrastructure rather than fantasy logic: authenticate the ChatGPT user, complete Yahoo OAuth for that user, store Yahoo refresh tokens encrypted per user, bind the resulting credential record to each MCP request, and trim the exposed tool set to the consumer-facing read/analysis tools needed for review and launch.
 
 ## Project structure
 
@@ -164,10 +166,6 @@ fantasy-football-mcp-public/
 ├── Dockerfile
 └── requirements.txt
 ```
-
-## Public-app path
-
-The core fantasy logic and MCP transport already exist. The remaining production work is primarily application infrastructure: authenticate the ChatGPT/app user, complete Yahoo OAuth for that user, store Yahoo refresh tokens securely per user, bind the resulting credential record to each MCP request, and expose a smaller consumer-facing tool set for review and launch.
 
 ## License
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The README previously read as if another person would deploy this project as a multi-user service. This rewrite reframes it to match the actual intent: a personal, single-user app whose code is deliberately structured so it can later be submitted to the ChatGPT app store.

## Changes

- **Intro and "Current status"** now state up front that this is a single-user app run with your own Yahoo credentials, and that the multi-user plumbing exists as groundwork for a future app store submission — not something a reader needs to use.
- **"Authentication modes"** simplified to a single "Authentication" section covering the supported env-var setup. The request-scoped `YahooCredentials` example moved out of the setup flow.
- **New "ChatGPT app store readiness" section** consolidates the multi-user material (request-scoped credentials, isolated token refresh, per-user cache namespacing) and the remaining work needed before submission, replacing the old "Public-app path" section.
- **Security notes** trimmed to what matters for a single-user setup (multi-user-deployment guidance moved into the readiness section's framing).

No code changes — README only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-200dbf7c-79d3-4640-a95d-a64293a425b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-200dbf7c-79d3-4640-a95d-a64293a425b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

