### PR TITLE
Add live Yahoo draft recorder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,10 @@ enhanced_mcp_*.py
 !test_enhancement_layer.py
 !test_real_data.py
 !demo_enhancement_layer.py
+!chrome-extension/tests/
+!chrome-extension/tests/**
+!tests/
+!tests/test_live_draft_store.py
 
 # Temporary and analysis files
 temp/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The main FastMCP server currently exposes:
 - `ff_compare_teams`
 - `ff_build_lineup`
 - `ff_get_draft_results`
+- `ff_get_live_draft_state`
 - `ff_get_waiver_wire`
 - `ff_get_draft_rankings`
 - `ff_get_draft_recommendation`
@@ -71,6 +72,14 @@ YAHOO_GUID=...
 ```
 
 This single-user mode is the supported way to run the app.
+
+## Browser extension: live draft recording
+
+The optional [Yahoo Fantasy Draft Recorder](chrome-extension/README.md) works in Firefox and Chrome. It watches a logged-in Yahoo live draft, captures the full **Results → Round by Round** ledger, saves picks locally in the browser, and exports CSV or agent-ready JSON. It never stores Yahoo authentication data.
+
+When this FastMCP server is running locally on port 8765 (`PORT=8765 python fastmcp_server.py`), the extension also syncs sanitized draft context to a loopback-only endpoint. Agents can call `ff_get_live_draft_state` to retrieve every pick, your roster, and rosters grouped by fantasy team before advising on the next selection. Local server state is written to `~/.fantasy-football-mcp/live-drafts.json` with user-only permissions.
+
+For Firefox, load `chrome-extension/manifest.json` from **This Firefox** in `about:debugging`. See the extension README for full setup, privacy, persistence, and testing instructions.
 
 ## Running the MCP server
 

--- a/chrome-extension/CHROMEWEBSTORE.md
+++ b/chrome-extension/CHROMEWEBSTORE.md
@@ -1,0 +1,64 @@
+# Chrome Web Store submission notes
+
+Keep this file aligned with `manifest.json` and the extension's actual behavior.
+
+## Single purpose
+
+Yahoo Fantasy Draft Recorder records completed picks shown in a Yahoo Fantasy Football live draft and lets the user review, export, or share those picks with a fantasy-football MCP server running on the same computer.
+
+## Suggested listing
+
+**Name:** Yahoo Fantasy Draft Recorder
+
+**Summary:** Record Yahoo Fantasy Football live draft picks and share them with your local recommendation agent.
+
+**Detailed description:**
+
+Yahoo Fantasy Draft Recorder watches the Round-by-Round results on an open Yahoo Fantasy Football draft page. It records the overall pick, round, player, NFL position and team, drafting fantasy team, and recording time. Open the extension popup to review the latest picks, rescan the page, clear local history, export CSV, or download agent-ready JSON.
+
+When the user's fantasy-football MCP server is running locally, the extension sends sanitized draft context to `127.0.0.1` so the user's own agent can make next-pick recommendations. It does not send draft data to the extension developer or a third party, read Yahoo credentials, or retain Yahoo authentication URL parameters.
+
+## Permission justifications
+
+### `storage`
+
+Required to save recorded draft picks in `chrome.storage.local` so history remains available when the popup closes or the Yahoo draft page reloads. The extension stores draft metadata and picks only. It does not store cookies, credentials, or Yahoo URL authentication parameters.
+
+### Host access: `https://football.fantasysports.yahoo.com/draftclient/*`
+
+Required to run the content script only on Yahoo Fantasy Sports draft-client pages. The content script reads completed-pick rows from the page DOM and watches that DOM for newly posted picks. Access is restricted to `/draftclient/`; the extension does not request access to unrelated Yahoo pages.
+
+### Host access: `http://127.0.0.1/*`
+
+Required to send sanitized draft context to the user's optional fantasy-football MCP server on the same computer. The extension uses only `http://127.0.0.1:8765/draft-sync`. Failed connections are ignored so browser-only recording and manual export continue to work without the server.
+
+## Data-use disclosure
+
+- **Data handled:** Fantasy sports draft selections, fantasy team names displayed in the draft, and local recording timestamps.
+- **Storage:** Local Chrome extension storage in the user's browser profile and, if enabled by running the local MCP server, a user-owned state file on the same computer.
+- **Transmission:** Sanitized draft context is sent only to `127.0.0.1`, the loopback interface. There are no developer-operated endpoints, analytics, advertising, or third-party requests.
+- **Sale or sharing:** None.
+- **Authentication data:** Not collected or stored.
+- **User controls:** Users can clear a draft from the popup and can remove all extension data by uninstalling the extension or clearing its site/extension storage.
+
+## Remote code
+
+None. All JavaScript used by the extension is packaged with it. There are no remotely hosted scripts, WebAssembly modules, `eval()` calls, or dynamic code downloads.
+
+## Content and security notes
+
+- Popup table content is written with `textContent`, not interpreted as HTML.
+- CSV export neutralizes formula-leading characters to reduce spreadsheet injection risk.
+- The draft URL parser keeps only the sport, league ID, and team ID path segments; query parameters are discarded.
+- The extension requests only `storage`, narrowly scoped Yahoo draft-client host access, and loopback host access for the local MCP sync endpoint.
+
+## Submission checklist
+
+- [ ] Replace or confirm the suggested listing text.
+- [ ] Add store icon and promotional images in the required sizes.
+- [ ] Capture screenshots without private league or manager information.
+- [ ] Publish a privacy policy URL if required by the Developer Dashboard.
+- [ ] Run `npm --prefix chrome-extension test`.
+- [ ] Test loading, recording, rescanning, clearing, and both export formats in current stable Chrome.
+- [ ] Confirm permission justifications still match `manifest.json`.
+- [ ] Confirm the extension contains no secrets, private draft URLs, or authentication tokens.

--- a/chrome-extension/README.md
+++ b/chrome-extension/README.md
@@ -1,0 +1,85 @@
+# Yahoo Fantasy Draft Recorder
+
+A Firefox- and Chrome-compatible Manifest V3 WebExtension that watches a Yahoo Fantasy Football live draft, records completed picks in local extension storage, syncs agent-ready context to the local MCP server, and exports the draft as CSV or JSON.
+
+## What it records
+
+When Yahoo exposes the data in the draft row, each pick includes:
+
+- Overall pick
+- Round and pick within the round
+- Player
+- NFL position and team
+- Fantasy team/manager
+- Local recording timestamp
+
+The extension scans the existing draft log when it loads and then watches DOM changes for new picks. Duplicate observations are merged using the overall pick number. Yahoo's **Results → Round by Round** table provides the authoritative all-team ledger; open that view once to backfill every completed pick. The smaller `Last:` banner continues capturing new picks while other draft tabs are visible.
+
+Rows labeled **Your Team** are marked as your picks and are highlighted in the popup.
+
+## Install temporarily in Firefox
+
+This does not require Chrome's **Load unpacked** feature:
+
+1. Open `about:debugging` in Firefox.
+2. Select **This Firefox**.
+3. Click **Load Temporary Add-on…**.
+4. Select `chrome-extension/manifest.json` from this repository.
+5. Open or reload a Yahoo live draft under `https://football.fantasysports.yahoo.com/draftclient/...`.
+6. Open **Results → Round by Round** once, then click the extension icon and select **Rescan page**.
+7. Use the popup to review, export, or clear recorded picks.
+
+After changing the code, use **Reload** for the add-on in `about:debugging`, then reload the Yahoo draft tab.
+
+A temporary add-on is removed when Firefox restarts. Permanent installation in standard Firefox requires a Mozilla-signed package, either through an addons.mozilla.org listing or an unlisted AMO signing submission.
+
+## Agent handoff
+
+### Automatic local MCP sync
+
+Start the FastMCP server on its default loopback port before opening the draft:
+
+```bash
+PORT=8765 python fastmcp_server.py
+```
+
+After each changed scan, the extension posts sanitized agent context to `http://127.0.0.1:8765/draft-sync`. An agent connected to this MCP server can call `ff_get_live_draft_state` immediately before recommending the next pick. Synced state is stored with user-only file permissions at `~/.fantasy-football-mcp/live-drafts.json`.
+
+The endpoint accepts writes only from the loopback interface and validates and whitelists every field. If the server is not running, recording still works and the popup reports that agent sync is offline.
+
+### Manual handoff
+
+Click **Agent JSON** to download a recommendation-ready file containing:
+
+- The complete ordered pick ledger
+- Your roster
+- Rosters grouped by fantasy team
+- Current and next overall-pick numbers
+- Sanitized draft identifiers
+
+CSV remains available for spreadsheet use.
+
+## Privacy
+
+- Pick history stays in the current browser profile and, when local sync is available, in the user-owned MCP state file on the same computer.
+- No draft data is sent to Yahoo beyond normal page use, to the extension developer, or to any third party.
+- The extension does not store or sync the draft URL, Yahoo cookies, the `auth` query parameter, or Yahoo credentials.
+- Host access is limited to Yahoo's `/draftclient/` pages and the loopback sync endpoint.
+
+## Yahoo layout changes
+
+Yahoo can change its draft page without notice. Detection favors semantic attributes (`data-pick-number`, player/team labels, ARIA labels) and falls back to common draft-row text formats. If the popup says rows were found but could not be parsed, capture the HTML for one completed-pick row from DevTools so its selector can be added to `dom-scanner.js`.
+
+## Store preparation
+
+`manifest.json` includes a stable Firefox add-on ID, Firefox 142 minimum version, and Firefox's required `none` data-collection declaration. `CHROMEWEBSTORE.md` tracks the single purpose, listing copy, permission justifications, data-use disclosures, remote-code declaration, and Chrome submission checklist. Keep these synchronized when behavior or permissions change.
+
+## Tests
+
+No package installation is required; the tests use Node's built-in test runner.
+
+```bash
+npm --prefix chrome-extension test
+```
+
+The tests cover URL sanitization, Round-by-Round parsing, duplicate merging, local session updates, agent-context creation, loopback sync requests, DOM snapshotting, Firefox/Chrome API compatibility, and CSV/JSON export safety.

--- a/chrome-extension/agent-context.js
+++ b/chrome-extension/agent-context.js
@@ -1,0 +1,65 @@
+(function initAgentContext(globalScope) {
+  'use strict';
+
+  const PICK_FIELDS = [
+    'pickNumber',
+    'roundNumber',
+    'roundPick',
+    'player',
+    'position',
+    'nflTeam',
+    'fantasyTeam',
+    'isUserPick',
+    'recordedAt',
+  ];
+
+  function safePick(pick) {
+    const result = {};
+    for (const field of PICK_FIELDS) {
+      const value = pick?.[field];
+      if (value !== undefined && value !== null && value !== '') result[field] = value;
+    }
+    return result;
+  }
+
+  function sessionToAgentContext(session, generatedAt = new Date().toISOString()) {
+    const picks = (session?.picks || [])
+      .map(safePick)
+      .sort((left, right) => Number(left.pickNumber || Number.MAX_SAFE_INTEGER) - Number(right.pickNumber || Number.MAX_SAFE_INTEGER));
+    const userRoster = picks.filter((pick) => pick.isUserPick === true || /^Your Team$/i.test(pick.fantasyTeam || ''));
+    const rosterEntries = new Map();
+    for (const pick of picks) {
+      const team = pick.fantasyTeam || 'Unknown team';
+      if (!rosterEntries.has(team)) rosterEntries.set(team, []);
+      rosterEntries.get(team).push(pick);
+    }
+    const numberedPicks = picks.map((pick) => Number(pick.pickNumber)).filter(Number.isFinite);
+    const latestOverallPick = numberedPicks.length ? Math.max(...numberedPicks) : 0;
+
+    return {
+      schemaVersion: 1,
+      source: 'yahoo-draft-recorder',
+      generatedAt,
+      draft: {
+        sport: session?.sport,
+        leagueId: session?.leagueId,
+        teamId: session?.teamId,
+        sessionKey: session?.sessionKey,
+        updatedAt: session?.updatedAt,
+      },
+      summary: {
+        totalPicks: picks.length,
+        latestOverallPick,
+        nextOverallPick: latestOverallPick + 1,
+        userPickCount: userRoster.length,
+      },
+      userRoster,
+      teamRosters: Object.fromEntries(rosterEntries),
+      picks,
+    };
+  }
+
+  const api = { sessionToAgentContext };
+  globalScope.YahooDraftAgentContext = api;
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,0 +1,137 @@
+(function startYahooDraftRecorder() {
+  'use strict';
+
+  const STORAGE_KEY = 'yahooDraftRecorderSessions';
+  const extensionApi = YahooDraftWebExtension.createWebExtensionApi(globalThis);
+  const webext = extensionApi.native;
+  const metadata = YahooDraftParser.parseDraftUrl(window.location.href);
+  if (!metadata) return;
+
+  let scanTimer;
+  let scanInProgress = null;
+  let lastSyncedSignature;
+  let lastSyncAttemptAt = 0;
+  const diagnostics = {
+    sessionKey: metadata.sessionKey,
+    lastScanAt: null,
+    candidateCount: 0,
+    parsedCount: 0,
+    ledgerCandidateCount: 0,
+    recordedCount: 0,
+    syncStatus: 'not-attempted',
+    lastSyncAt: null,
+    syncError: null,
+  };
+
+  async function getStorage() {
+    const result = await extensionApi.storageGet(STORAGE_KEY);
+    return result[STORAGE_KEY] || {};
+  }
+
+  function setStorage(sessions) {
+    return extensionApi.storageSet({ [STORAGE_KEY]: sessions });
+  }
+
+  async function syncSession(session) {
+    const signature = JSON.stringify([session.sessionKey, session.picks]);
+    const now = Date.now();
+    if (signature === lastSyncedSignature && diagnostics.syncStatus === 'connected') return;
+    if (signature === lastSyncedSignature && now - lastSyncAttemptAt < 10000) return;
+
+    lastSyncedSignature = signature;
+    lastSyncAttemptAt = now;
+    diagnostics.syncStatus = 'connecting';
+    diagnostics.syncError = null;
+    try {
+      const context = YahooDraftAgentContext.sessionToAgentContext(session);
+      await YahooDraftSyncClient.syncDraftContext(context);
+      diagnostics.syncStatus = 'connected';
+      diagnostics.lastSyncAt = new Date().toISOString();
+    } catch (error) {
+      diagnostics.syncStatus = 'unavailable';
+      diagnostics.syncError = error?.name === 'AbortError' ? 'Connection timed out' : String(error?.message || error);
+    }
+  }
+
+  async function performScan() {
+    const now = new Date().toISOString();
+    const snapshots = YahooDraftDomScanner.findPickSnapshots(document);
+    const ledgerSnapshots = YahooDraftDomScanner.findRoundByRoundSnapshots(document);
+    const picks = [
+      ...snapshots.map((snapshot) => YahooDraftParser.parsePickSnapshot(snapshot)),
+      ...ledgerSnapshots.map((snapshot) => YahooDraftParser.parseRoundByRoundSnapshot(snapshot)),
+    ].filter(Boolean);
+    const liveSnapshot = YahooDraftDomScanner.findLiveDraftSnapshot(document);
+    const livePick = liveSnapshot
+      ? YahooDraftParser.parseLiveDraftSnapshot(liveSnapshot)
+      : null;
+    if (livePick) picks.push(livePick);
+
+    diagnostics.lastScanAt = now;
+    diagnostics.ledgerCandidateCount = ledgerSnapshots.length;
+    diagnostics.candidateCount = snapshots.length + ledgerSnapshots.length + (liveSnapshot ? 1 : 0);
+    diagnostics.parsedCount = picks.length;
+
+    const sessions = await getStorage();
+    const existing = sessions[metadata.sessionKey];
+    const updated = YahooDraftSessionStore.updateDraftSession(existing, metadata, picks, now);
+    diagnostics.recordedCount = updated.picks.length;
+
+    if (JSON.stringify(existing?.picks || []) !== JSON.stringify(updated.picks)) {
+      sessions[metadata.sessionKey] = updated;
+      await setStorage(sessions);
+    }
+
+    await syncSession(updated);
+    return { ...diagnostics };
+  }
+
+  function scanNow() {
+    if (!scanInProgress) {
+      scanInProgress = performScan()
+        .catch((error) => {
+          console.warn('[Yahoo Draft Recorder] Scan failed:', error);
+          return { ...diagnostics, error: error.message };
+        })
+        .finally(() => {
+          scanInProgress = null;
+        });
+    }
+    return scanInProgress;
+  }
+
+  function scheduleScan() {
+    window.clearTimeout(scanTimer);
+    scanTimer = window.setTimeout(scanNow, 400);
+  }
+
+  const observer = new MutationObserver(scheduleScan);
+  observer.observe(document.documentElement, { childList: true, subtree: true, characterData: true });
+
+  webext.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    if (message?.type === 'YAHOO_DRAFT_RECORDER_STATUS') {
+      sendResponse({ ...diagnostics });
+      return false;
+    }
+    if (message?.type === 'YAHOO_DRAFT_RECORDER_RESCAN') {
+      scanNow().then(sendResponse);
+      return true;
+    }
+    if (message?.type === 'YAHOO_DRAFT_RECORDER_DIAGNOSTICS') {
+      sendResponse({
+        generatedAt: new Date().toISOString(),
+        session: {
+          sport: metadata.sport,
+          leagueId: metadata.leagueId,
+          teamId: metadata.teamId,
+        },
+        scanner: { ...diagnostics },
+        elements: YahooDraftDomScanner.collectDiagnosticSnapshots(document),
+      });
+      return false;
+    }
+    return false;
+  });
+
+  scanNow();
+})();

--- a/chrome-extension/dom-scanner.js
+++ b/chrome-extension/dom-scanner.js
@@ -1,0 +1,203 @@
+(function initDomScanner(globalScope) {
+  'use strict';
+
+  const CANDIDATE_SELECTOR = [
+    '[data-pick-number]',
+    '[data-overall-pick]',
+    '[data-pick]',
+    '[data-testid*="pick" i]',
+    '[data-test*="pick" i]',
+    '[class*="draft-pick" i]',
+    '[class*="draftPick"]',
+    '[class*="pick-row" i]',
+    '[aria-label*="draft pick" i]',
+    '[aria-label^="pick " i]',
+    '[class*="draft" i] [role="row"]',
+    '[data-testid*="draft" i] [role="row"]',
+  ].join(',');
+
+  const FIELD_SELECTORS = {
+    player: [
+      '[data-player-name]',
+      '[data-testid*="player-name" i]',
+      '[data-test*="player-name" i]',
+      '[class*="player-name" i]',
+      '[class*="playerName"]',
+    ],
+    position: [
+      '[data-position]',
+      '[data-testid*="position" i]',
+      '[class*="position" i]',
+    ],
+    nflTeam: [
+      '[data-nfl-team]',
+      '[data-testid*="nfl-team" i]',
+      '[class*="nfl-team" i]',
+    ],
+    fantasyTeam: [
+      '[data-fantasy-team]',
+      '[data-team-name]',
+      '[data-testid*="team-name" i]',
+      '[data-test*="team-name" i]',
+      '[class*="team-name" i]',
+      '[class*="teamName"]',
+    ],
+    pickNumber: ['[data-pick-number]', '[data-overall-pick]'],
+    roundNumber: ['[data-round-number]', '[data-round]'],
+    roundPick: ['[data-round-pick]', '[data-pick-in-round]'],
+  };
+
+  const ATTRIBUTE_NAMES = [
+    'aria-label',
+    'data-pick-number',
+    'data-overall-pick',
+    'data-pick',
+    'data-round-number',
+    'data-round',
+    'data-round-pick',
+    'data-pick-in-round',
+    'data-player-name',
+    'data-player',
+    'data-position',
+    'data-nfl-team',
+    'data-team-name',
+    'data-fantasy-team',
+    'data-manager-name',
+  ];
+
+  function clean(value) {
+    return String(value ?? '').replace(/\u00a0/g, ' ').replace(/[ \t]+/g, ' ').trim();
+  }
+
+  function readField(element, selectors) {
+    const node = element.querySelector(selectors.join(','));
+    return clean(node?.textContent || node?.getAttribute?.('aria-label')) || undefined;
+  }
+
+  function snapshotPickElement(element) {
+    const text = clean(element?.textContent);
+    if (!text || text.length > 800) return null;
+
+    const attributes = {};
+    for (const name of ATTRIBUTE_NAMES) {
+      const value = clean(element.getAttribute?.(name));
+      if (value) attributes[name] = value;
+    }
+
+    const labels = {};
+    for (const [field, selectors] of Object.entries(FIELD_SELECTORS)) {
+      const value = readField(element, selectors);
+      if (value) labels[field] = value;
+    }
+
+    return { text, attributes, labels };
+  }
+
+  function findPickSnapshots(root) {
+    const elements = root?.querySelectorAll?.(CANDIDATE_SELECTOR) || [];
+    const snapshots = [];
+    const seen = new Set();
+    for (const element of elements) {
+      if (seen.has(element)) continue;
+      seen.add(element);
+      const snapshot = snapshotPickElement(element);
+      if (snapshot) snapshots.push(snapshot);
+    }
+    return snapshots;
+  }
+
+  function findRoundByRoundSnapshots(root) {
+    const tables = root?.querySelectorAll?.('table') || [];
+    const snapshots = [];
+
+    for (const table of tables) {
+      const heading = clean(table.querySelector?.('thead')?.innerText || table.querySelector?.('thead')?.textContent);
+      if (!/^Pick\s+Player\s+Team$/i.test(heading.replace(/\s+/g, ' '))) continue;
+
+      let roundText;
+      const rows = table.querySelectorAll?.('tr') || [];
+      for (const row of rows) {
+        const rowText = clean(row.innerText || row.textContent);
+        const roundMatch = rowText.match(/^ROUND\s+\d+$/i);
+        if (roundMatch) {
+          roundText = roundMatch[0];
+          continue;
+        }
+
+        const cells = row.querySelectorAll?.('td') || [];
+        if (cells.length !== 3 || !/^\s*\d+\s*$/.test(cells[0].innerText || cells[0].textContent || '')) continue;
+        snapshots.push({
+          roundText,
+          pickText: clean(cells[0].innerText || cells[0].textContent),
+          playerText: clean(cells[1].innerText || cells[1].textContent),
+          fantasyTeamText: clean(cells[2].innerText || cells[2].textContent),
+        });
+      }
+    }
+
+    return snapshots;
+  }
+
+  function findLiveDraftSnapshot(root) {
+    const elements = root?.querySelectorAll?.('body *') || [];
+    let statusText;
+    let lastPickText;
+
+    for (const element of elements) {
+      const text = clean(element?.innerText || element?.textContent);
+      if (!text || text.length > 300) continue;
+      const flatText = text.replace(/\s+/g, ' ');
+      if (/\bROUND\s+\d+\s*[,•·-]?\s*PICK\s*#?\s*\d+\b/i.test(flatText) || /^Draft Paused$/i.test(flatText)) {
+        if (!statusText || text.length < statusText.length) statusText = text;
+      }
+      if (/^Last\s*:.*\)\s*\S/i.test(flatText)) {
+        if (!lastPickText || text.length < lastPickText.length) lastPickText = text;
+      }
+    }
+
+    return statusText && lastPickText ? { statusText, lastPickText } : null;
+  }
+
+  function collectDiagnosticSnapshots(root) {
+    const elements = root?.querySelectorAll?.('body *') || [];
+    const diagnostics = [];
+    const seen = new Set();
+    const footballSignal = /\b(?:QB|RB|WR|TE|K|DEF|DST|WRT|BN|bye|round|pick|draft)\b/i;
+
+    for (const element of elements) {
+      const text = clean(element?.innerText || element?.textContent);
+      if (!text || text.length > 600 || !footballSignal.test(text)) continue;
+
+      const snapshot = {
+        tag: clean(element.tagName).toLowerCase(),
+        role: clean(element.getAttribute?.('role')) || undefined,
+        className: clean(element.className).slice(0, 200) || undefined,
+        testId: clean(element.getAttribute?.('data-testid') || element.getAttribute?.('data-test')) || undefined,
+        ariaLabel: clean(element.getAttribute?.('aria-label')).slice(0, 200) || undefined,
+        childCount: Number(element.childElementCount || 0),
+        text,
+      };
+      for (const key of Object.keys(snapshot)) {
+        if (snapshot[key] === undefined) delete snapshot[key];
+      }
+
+      const signature = JSON.stringify(snapshot);
+      if (seen.has(signature)) continue;
+      seen.add(signature);
+      diagnostics.push(snapshot);
+      if (diagnostics.length >= 500) break;
+    }
+    return diagnostics;
+  }
+
+  const api = {
+    CANDIDATE_SELECTOR,
+    collectDiagnosticSnapshots,
+    findLiveDraftSnapshot,
+    findPickSnapshots,
+    findRoundByRoundSnapshots,
+    snapshotPickElement,
+  };
+  globalScope.YahooDraftDomScanner = api;
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/chrome-extension/draft-parser.js
+++ b/chrome-extension/draft-parser.js
@@ -1,0 +1,300 @@
+(function initDraftParser(globalScope) {
+  'use strict';
+
+  const POSITION_PATTERN = '(QB|RB|WR|TE|K|DEF|DST)';
+  const TEAM_PATTERN = '([A-Z]{2,3})';
+
+  function normalizeText(value) {
+    return String(value ?? '')
+      .replace(/\u00a0/g, ' ')
+      .replace(/[ \t]+/g, ' ')
+      .trim();
+  }
+
+  function positiveInteger(value) {
+    const match = String(value ?? '').match(/\d+/);
+    if (!match) return undefined;
+    const number = Number.parseInt(match[0], 10);
+    return number > 0 ? number : undefined;
+  }
+
+  function normalizePosition(value) {
+    const normalized = normalizeText(value).toUpperCase();
+    if (!normalized) return undefined;
+    return normalized === 'DST' ? 'DEF' : normalized;
+  }
+
+  function parseDraftUrl(value) {
+    try {
+      const url = new URL(value);
+      if (url.hostname !== 'football.fantasysports.yahoo.com') return null;
+      const match = url.pathname.match(/^\/draftclient\/([^/]+)\/([^/]+)\/([^/]+)/);
+      if (!match) return null;
+      const [, sport, leagueId, teamId] = match;
+      return { sport, leagueId, teamId, sessionKey: `${sport}:${leagueId}` };
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  function firstValue(...values) {
+    for (const value of values) {
+      const normalized = normalizeText(value);
+      if (normalized) return normalized;
+    }
+    return undefined;
+  }
+
+  function attributeValue(attributes, ...names) {
+    for (const name of names) {
+      if (attributes && attributes[name] != null) return attributes[name];
+    }
+    return undefined;
+  }
+
+  function parseTeamAndPosition(text) {
+    const teamThenPosition = text.match(
+      new RegExp(`\\b${TEAM_PATTERN}\\s*[-–|/,]?\\s*${POSITION_PATTERN}\\b`, 'i'),
+    );
+    if (teamThenPosition) {
+      return {
+        nflTeam: teamThenPosition[1].toUpperCase(),
+        position: normalizePosition(teamThenPosition[2]),
+      };
+    }
+
+    const positionThenTeam = text.match(
+      new RegExp(`\\b${POSITION_PATTERN}\\s*[-–|/,]?\\s*${TEAM_PATTERN}\\b`, 'i'),
+    );
+    if (positionThenTeam) {
+      return {
+        position: normalizePosition(positionThenTeam[1]),
+        nflTeam: positionThenTeam[2].toUpperCase(),
+      };
+    }
+    return {};
+  }
+
+  function parsePickSnapshot(snapshot) {
+    const text = normalizeText(snapshot?.text);
+    const lines = String(snapshot?.text ?? '')
+      .split(/\r?\n/)
+      .map(normalizeText)
+      .filter(Boolean);
+    const labels = snapshot?.labels || {};
+    const attributes = snapshot?.attributes || {};
+
+    const pick = {};
+    const pickNumber = positiveInteger(
+      firstValue(
+        labels.pickNumber,
+        attributeValue(attributes, 'data-pick-number', 'data-pick', 'data-overall-pick'),
+        text.match(/(?:\(|\b)(\d+)(?:st|nd|rd|th)?\s+overall\b/i)?.[1],
+        text.match(/\b(?:overall\s+)?pick\s*#?\s*(\d+)\b/i)?.[1],
+        lines[0]?.match(/^#?\s*(\d+)(?:[.)]|$)/)?.[1],
+      ),
+    );
+    if (pickNumber) pick.pickNumber = pickNumber;
+
+    const roundNumber = positiveInteger(
+      firstValue(
+        labels.roundNumber,
+        attributeValue(attributes, 'data-round-number', 'data-round'),
+        text.match(/\bround\s*#?\s*(\d+)\b/i)?.[1],
+      ),
+    );
+    if (roundNumber) pick.roundNumber = roundNumber;
+
+    const roundPick = positiveInteger(
+      firstValue(
+        labels.roundPick,
+        attributeValue(attributes, 'data-round-pick', 'data-pick-in-round'),
+        text.match(/\bround\s+\d+\s*[,;:-]\s*pick\s*#?\s*(\d+)\b/i)?.[1],
+      ),
+    );
+    if (roundPick) pick.roundPick = roundPick;
+
+    let player = firstValue(
+      labels.player,
+      attributeValue(attributes, 'data-player-name', 'data-player'),
+    );
+    let fantasyTeam = firstValue(
+      labels.fantasyTeam,
+      attributeValue(attributes, 'data-team-name', 'data-fantasy-team', 'data-manager-name'),
+    );
+    let position = firstValue(labels.position, attributeValue(attributes, 'data-position'));
+    let nflTeam = firstValue(labels.nflTeam, attributeValue(attributes, 'data-nfl-team'));
+
+    const sentenceMatch = text.match(
+      /\bpick\s*#?\s*\d+\s*[:.-]\s*(.+?)\s*\(([A-Z]{2,3})\s*[-–|/,]\s*(QB|RB|WR|TE|K|DEF|DST)\)\s*(?:-|–|—)?\s*(?:drafted\s+by|selected\s+by|team\s*:?)\s*(.+)$/i,
+    );
+    if (sentenceMatch) {
+      player ||= normalizeText(sentenceMatch[1]);
+      nflTeam ||= sentenceMatch[2];
+      position ||= sentenceMatch[3];
+      fantasyTeam ||= normalizeText(sentenceMatch[4]);
+    }
+
+    const detailedAnnouncement = text.match(
+      /:\s*(.+?)\s*\(([A-Z]{2,3})\s*[-–|/,]\s*(QB|RB|WR|TE|K|DEF|DST)\)\s*(?:-|–|—)?\s*(?:drafted\s+by|selected\s+by|team\s*:?)\s*(.+)$/i,
+    );
+    if (detailedAnnouncement) {
+      player ||= normalizeText(detailedAnnouncement[1]);
+      nflTeam ||= detailedAnnouncement[2];
+      position ||= detailedAnnouncement[3];
+      fantasyTeam ||= normalizeText(detailedAnnouncement[4]);
+    }
+
+    const compactRow = text.match(
+      /^#?\s*\d+[.)]?\s*(?:\(\d+\)\s*)?(.+?)\s*\(([A-Z]{2,3})\s*[-–|/,]\s*(QB|RB|WR|TE|K|DEF|DST)\)\s+(.+)$/i,
+    );
+    if (compactRow) {
+      player ||= normalizeText(compactRow[1]);
+      nflTeam ||= compactRow[2];
+      position ||= compactRow[3];
+      fantasyTeam ||= normalizeText(compactRow[4]);
+    }
+
+    if (!player && lines.length >= 3 && /^#?\s*\d+(?:[.)]|$)/.test(lines[0])) {
+      const detailsIndex = lines.findIndex((line, index) => index > 0 && Object.keys(parseTeamAndPosition(line)).length > 0);
+      if (detailsIndex > 1) {
+        player = lines[1].replace(/^\d+\.?\s*/, '');
+        fantasyTeam ||= lines[detailsIndex + 1];
+      }
+    }
+
+    const parsedTeamAndPosition = parseTeamAndPosition(
+      firstValue(position && nflTeam ? `${nflTeam} ${position}` : undefined, text) || '',
+    );
+    position ||= parsedTeamAndPosition.position;
+    nflTeam ||= parsedTeamAndPosition.nflTeam;
+
+    player = normalizeText(player);
+    fantasyTeam = normalizeText(fantasyTeam);
+    position = normalizePosition(position);
+    nflTeam = normalizeText(nflTeam).toUpperCase();
+
+    if (!player || !pick.pickNumber) return null;
+    if (!/\p{L}/u.test(player) || player.length > 100) return null;
+
+    pick.player = player;
+    if (position) pick.position = position;
+    if (nflTeam) pick.nflTeam = nflTeam;
+    if (fantasyTeam) pick.fantasyTeam = fantasyTeam;
+    return pick;
+  }
+
+  function parseRoundByRoundSnapshot({ roundText, pickText, playerText, fantasyTeamText }) {
+    const pickNumber = positiveInteger(pickText);
+    const roundNumber = positiveInteger(roundText);
+    const lines = String(playerText ?? '')
+      .split(/\r?\n/)
+      .map(normalizeText)
+      .filter(Boolean);
+    const positionIndex = lines.findIndex((line) => /^(QB|RB|WR|TE|K|DEF|DST)$/i.test(line));
+    const player = normalizeText(lines[0]);
+    const fantasyTeam = normalizeText(fantasyTeamText);
+
+    if (!pickNumber || positionIndex < 1 || !player || !fantasyTeam) return null;
+    const position = normalizePosition(lines[positionIndex]);
+    const nflTeam = normalizeText(lines[positionIndex + 1]).toUpperCase();
+    if (!nflTeam || !/^[A-Z]{2,3}$/.test(nflTeam)) return null;
+
+    const pick = {
+      pickNumber,
+      player,
+      position,
+      nflTeam,
+      fantasyTeam,
+      isUserPick: /^Your Team$/i.test(fantasyTeam),
+    };
+    if (roundNumber) pick.roundNumber = roundNumber;
+    return pick;
+  }
+
+  function parseLiveDraftSnapshot({ statusText, lastPickText }) {
+    const currentPick = positiveInteger(
+      normalizeText(statusText).match(/\bROUND\s+\d+\s*[,•·-]?\s*PICK\s*#?\s*(\d+)\b/i)?.[1],
+    );
+    const lastPick = normalizeText(lastPickText).match(
+      /^Last:\s*(.+?)\s*\(\s*(QB|RB|WR|TE|K|DEF|DST)\s*[·•|/,–-]\s*([A-Z]{2,3})\s*\)\s*(.+)$/i,
+    );
+    if (!lastPick) return null;
+
+    const pick = {
+      player: normalizeText(lastPick[1]),
+      position: normalizePosition(lastPick[2]),
+      nflTeam: lastPick[3].toUpperCase(),
+      fantasyTeam: normalizeText(lastPick[4]),
+    };
+    if (/^Your Team$/i.test(pick.fantasyTeam)) pick.isUserPick = true;
+    if (currentPick && currentPick > 1) pick.pickNumber = currentPick - 1;
+    return pick;
+  }
+
+  function slug(value) {
+    return normalizeText(value).toLocaleLowerCase().replace(/[^\p{L}\p{N}]+/gu, '-').replace(/^-|-$/g, '');
+  }
+
+  function buildPickKey(sessionKey, pick) {
+    if (positiveInteger(pick?.pickNumber)) {
+      return `${sessionKey}:pick:${positiveInteger(pick.pickNumber)}`;
+    }
+    return `${sessionKey}:player:${slug(pick?.player)}:team:${slug(pick?.fantasyTeam)}`;
+  }
+
+  function richerMerge(existing, incoming) {
+    const merged = { ...existing };
+    for (const [key, value] of Object.entries(incoming)) {
+      if (value !== undefined && value !== null && value !== '') merged[key] = value;
+    }
+    if (existing.recordedAt) merged.recordedAt = existing.recordedAt;
+    return merged;
+  }
+
+  function upsertPicks(sessionKey, existing, incoming) {
+    const picksByKey = new Map();
+    for (const pick of existing || []) picksByKey.set(buildPickKey(sessionKey, pick), { ...pick });
+    for (const pick of incoming || []) {
+      const key = buildPickKey(sessionKey, pick);
+      let targetKey = key;
+      let current = picksByKey.get(key);
+      if (positiveInteger(pick.pickNumber)) {
+        const fallbackKey = buildPickKey(sessionKey, { ...pick, pickNumber: undefined });
+        if (picksByKey.has(fallbackKey)) {
+          const fallback = picksByKey.get(fallbackKey);
+          current = current ? richerMerge(fallback, current) : fallback;
+          picksByKey.delete(fallbackKey);
+        }
+      } else if (!current) {
+        for (const [existingKey, existingPick] of picksByKey) {
+          const fallbackKey = buildPickKey(sessionKey, { ...existingPick, pickNumber: undefined });
+          if (fallbackKey === key) {
+            targetKey = existingKey;
+            current = existingPick;
+            break;
+          }
+        }
+      }
+      picksByKey.set(targetKey, current ? richerMerge(current, pick) : { ...pick });
+    }
+    return [...picksByKey.values()].sort((left, right) => {
+      const leftNumber = positiveInteger(left.pickNumber) ?? Number.MAX_SAFE_INTEGER;
+      const rightNumber = positiveInteger(right.pickNumber) ?? Number.MAX_SAFE_INTEGER;
+      return leftNumber - rightNumber || String(left.recordedAt || '').localeCompare(String(right.recordedAt || ''));
+    });
+  }
+
+  const api = {
+    buildPickKey,
+    normalizeText,
+    parseDraftUrl,
+    parseLiveDraftSnapshot,
+    parsePickSnapshot,
+    parseRoundByRoundSnapshot,
+    upsertPicks,
+  };
+
+  globalScope.YahooDraftParser = api;
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/chrome-extension/export.js
+++ b/chrome-extension/export.js
@@ -1,0 +1,38 @@
+(function initDraftExport(globalScope) {
+  'use strict';
+
+  const columns = [
+    ['Overall Pick', 'pickNumber'],
+    ['Round', 'roundNumber'],
+    ['Round Pick', 'roundPick'],
+    ['Player', 'player'],
+    ['Position', 'position'],
+    ['NFL Team', 'nflTeam'],
+    ['Fantasy Team', 'fantasyTeam'],
+    ['Your Pick', 'isUserPick'],
+    ['Recorded At', 'recordedAt'],
+  ];
+
+  function csvCell(value) {
+    let text = String(value ?? '');
+    if (/^[=+\-@]/.test(text)) text = `'${text}`;
+    if (/[",\r\n]/.test(text)) return `"${text.replace(/"/g, '""')}"`;
+    return text;
+  }
+
+  function picksToCsv(picks) {
+    const rows = [columns.map(([heading]) => heading).join(',')];
+    for (const pick of picks || []) {
+      rows.push(columns.map(([, key]) => csvCell(pick[key])).join(','));
+    }
+    return rows.join('\r\n');
+  }
+
+  function picksToJson(picks) {
+    return `${JSON.stringify(picks || [], null, 2)}\n`;
+  }
+
+  const api = { picksToCsv, picksToJson };
+  globalScope.YahooDraftExport = api;
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,0 +1,39 @@
+{
+  "manifest_version": 3,
+  "name": "Yahoo Fantasy Draft Recorder",
+  "description": "Records Yahoo Fantasy Football draft picks locally and shares live draft context with a local MCP server.",
+  "version": "0.3.2",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "yahoo-draft-recorder@fantasy-football-mcp",
+      "strict_min_version": "142.0",
+      "data_collection_permissions": {
+        "required": ["none"]
+      }
+    }
+  },
+  "permissions": ["storage"],
+  "host_permissions": [
+    "https://football.fantasysports.yahoo.com/draftclient/*",
+    "http://127.0.0.1/*"
+  ],
+  "action": {
+    "default_title": "Yahoo Draft Recorder",
+    "default_popup": "popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://football.fantasysports.yahoo.com/draftclient/*"],
+      "js": [
+        "webext-api.js",
+        "draft-parser.js",
+        "dom-scanner.js",
+        "agent-context.js",
+        "sync-client.js",
+        "session-store.js",
+        "content.js"
+      ],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "yahoo-draft-recorder-extension",
+  "private": true,
+  "version": "0.3.2",
+  "type": "commonjs",
+  "scripts": {
+    "test": "node --test tests/*.test.js"
+  }
+}

--- a/chrome-extension/popup.css
+++ b/chrome-extension/popup.css
@@ -1,0 +1,141 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #17231d;
+  background: #f4f7f5;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  width: 560px;
+  min-height: 420px;
+  margin: 0;
+  background: #f4f7f5;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 20px;
+  color: #fff;
+  background: linear-gradient(120deg, #2d085d, #5f1a8b);
+}
+
+h1, h2, p { margin: 0; }
+h1 { font-size: 21px; line-height: 1.1; }
+h2 { margin-bottom: 10px; font-size: 14px; }
+
+.eyebrow {
+  margin-bottom: 4px;
+  color: #d8c3ea;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: .14em;
+}
+
+.indicator {
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(255, 255, 255, .75);
+  border-radius: 50%;
+  background: #9aa39e;
+}
+
+.indicator.live {
+  background: #40d17d;
+  box-shadow: 0 0 0 5px rgba(64, 209, 125, .18);
+}
+
+main { padding: 16px 20px 14px; }
+
+.summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border: 1px solid #dbe4df;
+  border-radius: 12px;
+  background: #fff;
+}
+
+.summary-label {
+  display: block;
+  margin-bottom: 2px;
+  color: #6b7771;
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.pick-count { display: flex; align-items: baseline; gap: 5px; color: #5f1a8b; }
+.pick-count strong { font-size: 26px; }
+.pick-count span { color: #6b7771; font-size: 12px; }
+
+.status {
+  min-height: 34px;
+  padding: 10px 2px 8px;
+  color: #5d6963;
+  font-size: 12px;
+}
+
+.status.warning { color: #9a5900; }
+.status.error { color: #a72e2e; }
+
+.toolbar { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 18px; }
+button {
+  padding: 8px 11px;
+  border: 1px solid #cbd7d0;
+  border-radius: 8px;
+  color: #26342d;
+  background: #fff;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 700;
+}
+button:hover:not(:disabled) { border-color: #5f1a8b; color: #5f1a8b; }
+button:disabled { cursor: default; opacity: .48; }
+
+.table-wrap {
+  position: relative;
+  max-height: 245px;
+  overflow: auto;
+  border: 1px solid #dbe4df;
+  border-radius: 10px;
+  background: #fff;
+}
+
+table { width: 100%; border-collapse: collapse; font-size: 12px; }
+th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: 8px;
+  color: #65716b;
+  background: #f8faf9;
+  text-align: left;
+  font-size: 10px;
+  letter-spacing: .03em;
+  text-transform: uppercase;
+}
+td { padding: 9px 8px; border-top: 1px solid #edf1ef; vertical-align: top; }
+tr.user-pick td { background: #f4ebfb; }
+td:first-child { width: 38px; color: #6b7771; }
+.player { font-weight: 750; }
+.meta { color: #6b7771; font-size: 10px; }
+
+.empty { padding: 30px 14px; color: #7c8781; text-align: center; font-size: 12px; }
+
+footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px;
+  border-top: 1px solid #dbe4df;
+  color: #758079;
+  background: #fff;
+  font-size: 10px;
+}
+
+button.danger { padding: 5px 8px; border-color: transparent; color: #a72e2e; background: transparent; }

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Yahoo Draft Recorder</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <header>
+      <div>
+        <p class="eyebrow">YAHOO FANTASY</p>
+        <h1>Draft Recorder</h1>
+      </div>
+      <span id="recording-indicator" class="indicator" title="Recorder status"></span>
+    </header>
+
+    <main>
+      <section class="summary" aria-live="polite">
+        <div>
+          <span class="summary-label">Draft</span>
+          <strong id="draft-name">Not detected</strong>
+        </div>
+        <div class="pick-count">
+          <strong id="pick-count">0</strong>
+          <span>picks</span>
+        </div>
+      </section>
+
+      <p id="status" class="status">Open a Yahoo live draft to begin recording.</p>
+
+      <div class="toolbar">
+        <button id="rescan" type="button">Rescan page</button>
+        <button id="diagnostics" type="button">Save diagnostics</button>
+        <button id="export-csv" type="button" disabled>Export CSV</button>
+        <button id="export-json" type="button" disabled>Agent JSON</button>
+      </div>
+
+      <section class="picks-section">
+        <h2>Recorded picks</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">#</th>
+                <th scope="col">Player</th>
+                <th scope="col">NFL</th>
+                <th scope="col">Fantasy team</th>
+              </tr>
+            </thead>
+            <tbody id="picks"></tbody>
+          </table>
+          <p id="empty-state" class="empty">No picks recorded yet.</p>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <span>Stored only in this browser profile</span>
+      <button id="clear" class="danger" type="button" disabled>Clear draft</button>
+    </footer>
+
+    <script src="webext-api.js"></script>
+    <script src="agent-context.js"></script>
+    <script src="export.js"></script>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -1,0 +1,191 @@
+(function initPopup() {
+  'use strict';
+
+  const STORAGE_KEY = 'yahooDraftRecorderSessions';
+  const extensionApi = YahooDraftWebExtension.createWebExtensionApi(globalThis);
+  const webext = extensionApi.native;
+  const elements = {
+    indicator: document.querySelector('#recording-indicator'),
+    draftName: document.querySelector('#draft-name'),
+    count: document.querySelector('#pick-count'),
+    status: document.querySelector('#status'),
+    tbody: document.querySelector('#picks'),
+    empty: document.querySelector('#empty-state'),
+    rescan: document.querySelector('#rescan'),
+    diagnostics: document.querySelector('#diagnostics'),
+    csv: document.querySelector('#export-csv'),
+    json: document.querySelector('#export-json'),
+    clear: document.querySelector('#clear'),
+  };
+
+  let activeTabId;
+  let activeSessionKey;
+  let currentSession;
+
+  async function readSessions() {
+    const result = await extensionApi.storageGet(STORAGE_KEY);
+    return result[STORAGE_KEY] || {};
+  }
+
+  function writeSessions(sessions) {
+    return extensionApi.storageSet({ [STORAGE_KEY]: sessions });
+  }
+
+  async function getActiveTab() {
+    const tabs = await extensionApi.queryTabs({ active: true, currentWindow: true });
+    return tabs[0];
+  }
+
+  async function sendToActiveTab(type) {
+    if (!activeTabId) return null;
+    try {
+      return await extensionApi.sendTabMessage(activeTabId, { type });
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  function setStatus(message, kind = '') {
+    elements.status.textContent = message;
+    elements.status.className = `status ${kind}`.trim();
+  }
+
+  function appendCell(row, text, className = '') {
+    const cell = document.createElement('td');
+    cell.textContent = text || '—';
+    if (className) cell.className = className;
+    row.appendChild(cell);
+  }
+
+  function render(session, diagnostics) {
+    currentSession = session;
+    const picks = session?.picks || [];
+    const isLive = Boolean(diagnostics?.sessionKey);
+
+    elements.indicator.classList.toggle('live', isLive);
+    elements.indicator.title = isLive ? 'Watching this Yahoo draft' : 'No Yahoo draft detected';
+    elements.draftName.textContent = session?.leagueId ? `League ${session.leagueId}` : 'Not detected';
+    elements.count.textContent = String(picks.length);
+    elements.tbody.replaceChildren();
+
+    for (const pick of [...picks].reverse()) {
+      const row = document.createElement('tr');
+      if (pick.isUserPick === true || /^Your Team$/i.test(pick.fantasyTeam || '')) row.classList.add('user-pick');
+      appendCell(row, String(pick.pickNumber || ''));
+
+      const playerCell = document.createElement('td');
+      const player = document.createElement('div');
+      player.className = 'player';
+      player.textContent = pick.player || 'Unknown player';
+      playerCell.appendChild(player);
+      if (pick.roundNumber) {
+        const round = document.createElement('div');
+        round.className = 'meta';
+        round.textContent = `Round ${pick.roundNumber}${pick.roundPick ? `, pick ${pick.roundPick}` : ''}`;
+        playerCell.appendChild(round);
+      }
+      row.appendChild(playerCell);
+
+      appendCell(row, [pick.nflTeam, pick.position].filter(Boolean).join(' · '));
+      appendCell(row, pick.fantasyTeam || '');
+      elements.tbody.appendChild(row);
+    }
+
+    elements.empty.hidden = picks.length > 0;
+    elements.csv.disabled = picks.length === 0;
+    elements.json.disabled = picks.length === 0;
+    elements.clear.disabled = !session;
+    elements.rescan.disabled = !isLive;
+    elements.diagnostics.disabled = !isLive;
+
+    if (!isLive) {
+      setStatus(session ? 'Showing a saved draft. Open its Yahoo draft page to resume recording.' : 'Open a Yahoo live draft to begin recording.');
+    } else if (diagnostics.error) {
+      setStatus(`Recorder error: ${diagnostics.error}`, 'error');
+    } else if (diagnostics.candidateCount > 0 && diagnostics.parsedCount === 0) {
+      setStatus('Yahoo rows were found, but their fields could not be parsed. The page layout may have changed.', 'warning');
+    } else if (picks.length === 0) {
+      setStatus('Watching this draft. Picks will appear here as Yahoo posts them.');
+    } else {
+      const syncLabel = diagnostics.syncStatus === 'connected'
+        ? 'agent sync connected'
+        : 'agent sync offline; Agent JSON is available';
+      setStatus(`Recording automatically · ${syncLabel} · last scan ${new Date(diagnostics.lastScanAt).toLocaleTimeString()}`);
+    }
+  }
+
+  function latestSession(sessions) {
+    return Object.values(sessions).sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')))[0];
+  }
+
+  async function refresh() {
+    const [sessions, diagnostics] = await Promise.all([
+      readSessions(),
+      sendToActiveTab('YAHOO_DRAFT_RECORDER_STATUS'),
+    ]);
+    activeSessionKey = diagnostics?.sessionKey || null;
+    const saved = activeSessionKey ? sessions[activeSessionKey] : latestSession(sessions);
+    const session = saved || (diagnostics ? {
+      sessionKey: diagnostics.sessionKey,
+      leagueId: diagnostics.sessionKey.split(':').slice(1).join(':'),
+      picks: [],
+    } : null);
+    render(session, diagnostics);
+  }
+
+  function download(content, extension, mimeType) {
+    const blob = new Blob([content], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    const league = currentSession?.leagueId || 'draft';
+    anchor.href = url;
+    anchor.download = `yahoo-draft-${league}-${new Date().toISOString().slice(0, 10)}.${extension}`;
+    anchor.click();
+    window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+
+  elements.rescan.addEventListener('click', async () => {
+    setStatus('Scanning the Yahoo draft page…');
+    await sendToActiveTab('YAHOO_DRAFT_RECORDER_RESCAN');
+    await refresh();
+  });
+
+  elements.diagnostics.addEventListener('click', async () => {
+    setStatus('Collecting sanitized Yahoo row diagnostics…');
+    const report = await sendToActiveTab('YAHOO_DRAFT_RECORDER_DIAGNOSTICS');
+    if (!report) {
+      setStatus('Could not collect diagnostics from the active Yahoo draft tab.', 'error');
+      return;
+    }
+    download(`${JSON.stringify(report, null, 2)}\n`, 'diagnostics.json', 'application/json');
+    setStatus('Diagnostics saved to your Downloads folder.');
+  });
+
+  elements.csv.addEventListener('click', () => {
+    download(YahooDraftExport.picksToCsv(currentSession?.picks), 'csv', 'text/csv;charset=utf-8');
+  });
+
+  elements.json.addEventListener('click', () => {
+    const context = YahooDraftAgentContext.sessionToAgentContext(currentSession);
+    download(`${JSON.stringify(context, null, 2)}\n`, 'agent-context.json', 'application/json');
+  });
+
+  elements.clear.addEventListener('click', async () => {
+    if (!currentSession || !window.confirm('Clear every recorded pick for this draft?')) return;
+    const sessions = await readSessions();
+    delete sessions[currentSession.sessionKey];
+    await writeSessions(sessions);
+    await refresh();
+  });
+
+  webext.storage.onChanged.addListener((changes, area) => {
+    if (area === 'local' && changes[STORAGE_KEY]) refresh();
+  });
+
+  getActiveTab()
+    .then((tab) => {
+      activeTabId = tab?.id;
+      return refresh();
+    })
+    .catch((error) => setStatus(`Could not load recorded picks: ${error.message}`, 'error'));
+})();

--- a/chrome-extension/session-store.js
+++ b/chrome-extension/session-store.js
@@ -1,0 +1,29 @@
+(function initSessionStore(globalScope) {
+  'use strict';
+
+  const parser =
+    globalScope.YahooDraftParser ||
+    (typeof require === 'function' ? require('./draft-parser.js') : null);
+
+  function updateDraftSession(existing, metadata, observedPicks, timestamp) {
+    const existingPicks = existing?.picks || [];
+    const observedWithTimestamps = (observedPicks || []).map((pick) => ({
+      ...pick,
+      recordedAt: pick.recordedAt || timestamp,
+    }));
+
+    return {
+      ...(existing || {}),
+      sport: metadata.sport,
+      leagueId: metadata.leagueId,
+      teamId: metadata.teamId,
+      sessionKey: metadata.sessionKey,
+      picks: parser.upsertPicks(metadata.sessionKey, existingPicks, observedWithTimestamps),
+      updatedAt: timestamp,
+    };
+  }
+
+  const api = { updateDraftSession };
+  globalScope.YahooDraftSessionStore = api;
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/chrome-extension/sync-client.js
+++ b/chrome-extension/sync-client.js
@@ -1,0 +1,34 @@
+(function initDraftSyncClient(globalScope) {
+  'use strict';
+
+  const DEFAULT_ENDPOINT = 'http://127.0.0.1:8765/draft-sync';
+
+  async function syncDraftContext(context, options = {}) {
+    const fetchImpl = options.fetchImpl || globalScope.fetch?.bind(globalScope);
+    if (!fetchImpl) throw new Error('Fetch is unavailable');
+
+    const controller = typeof AbortController === 'function' ? new AbortController() : null;
+    const timeout = globalScope.setTimeout?.(() => controller?.abort(), options.timeoutMs || 2000);
+    try {
+      const response = await fetchImpl(options.endpoint || DEFAULT_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Yahoo-Draft-Recorder': '1',
+        },
+        body: JSON.stringify(context),
+        signal: controller?.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`MCP draft sync returned HTTP ${response.status || 'error'}`);
+      }
+      return await response.json();
+    } finally {
+      if (timeout !== undefined) globalScope.clearTimeout?.(timeout);
+    }
+  }
+
+  const api = { DEFAULT_ENDPOINT, syncDraftContext };
+  globalScope.YahooDraftSyncClient = api;
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/chrome-extension/tests/agent-context.test.js
+++ b/chrome-extension/tests/agent-context.test.js
@@ -1,0 +1,50 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { sessionToAgentContext } = require('../agent-context.js');
+
+test('builds recommendation-ready context with all picks and the user roster', () => {
+  const context = sessionToAgentContext(
+    {
+      sport: 'f1',
+      leagueId: '10462193',
+      teamId: '6',
+      sessionKey: 'f1:10462193',
+      updatedAt: '2026-08-31T22:44:58.255Z',
+      picks: [
+        { pickNumber: 1, player: 'J. Gibbs', position: 'RB', nflTeam: 'DET', fantasyTeam: 'Team 1', isUserPick: false },
+        { pickNumber: 6, player: 'P. Nacua', position: 'WR', nflTeam: 'LAR', fantasyTeam: 'Your Team', isUserPick: true },
+        { pickNumber: 19, player: 'S. Barkley', position: 'RB', nflTeam: 'PHI', fantasyTeam: 'Your Team', isUserPick: true },
+      ],
+    },
+    '2026-08-31T22:45:00.000Z',
+  );
+
+  assert.deepEqual(context.summary, {
+    totalPicks: 3,
+    latestOverallPick: 19,
+    nextOverallPick: 20,
+    userPickCount: 2,
+  });
+  assert.deepEqual(context.userRoster.map((pick) => pick.player), ['P. Nacua', 'S. Barkley']);
+  assert.deepEqual(Object.keys(context.teamRosters), ['Team 1', 'Your Team']);
+  assert.equal(context.generatedAt, '2026-08-31T22:45:00.000Z');
+  assert.equal(context.draft.leagueId, '10462193');
+  assert.equal(context.picks.length, 3);
+});
+
+test('does not include credentials, URLs, or arbitrary session properties', () => {
+  const context = sessionToAgentContext({
+    sport: 'f1',
+    leagueId: '123',
+    teamId: '6',
+    sessionKey: 'f1:123',
+    auth: 'secret',
+    url: 'https://example.test/?auth=secret',
+    picks: [],
+  });
+
+  assert.equal(JSON.stringify(context).includes('secret'), false);
+  assert.equal('auth' in context.draft, false);
+  assert.equal('url' in context.draft, false);
+});

--- a/chrome-extension/tests/dom-scanner.test.js
+++ b/chrome-extension/tests/dom-scanner.test.js
@@ -1,0 +1,178 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  collectDiagnosticSnapshots,
+  findLiveDraftSnapshot,
+  findRoundByRoundSnapshots,
+  snapshotPickElement,
+} = require('../dom-scanner.js');
+
+function node(textContent) {
+  return { textContent };
+}
+
+function fakeElement({ text, attributes = {}, selectors = {} }) {
+  return {
+    textContent: text,
+    getAttribute(name) {
+      return attributes[name] ?? null;
+    },
+    querySelector(selectorList) {
+      for (const selector of selectorList.split(',').map((value) => value.trim())) {
+        if (selectors[selector]) return selectors[selector];
+      }
+      return null;
+    },
+  };
+}
+
+test('snapshots semantic pick fields from a candidate element', () => {
+  const element = fakeElement({
+    text: 'Pick 9 Player details',
+    attributes: { 'data-pick-number': '9', 'aria-label': 'Draft pick 9' },
+    selectors: {
+      '[data-player-name]': node('Breece Hall'),
+      '[data-position]': node('RB'),
+      '[data-nfl-team]': node('NYJ'),
+      '[data-fantasy-team]': node('Gridiron Greats'),
+    },
+  });
+
+  assert.deepEqual(snapshotPickElement(element), {
+    text: 'Pick 9 Player details',
+    attributes: {
+      'aria-label': 'Draft pick 9',
+      'data-pick-number': '9',
+    },
+    labels: {
+      player: 'Breece Hall',
+      position: 'RB',
+      nflTeam: 'NYJ',
+      fantasyTeam: 'Gridiron Greats',
+    },
+  });
+});
+
+test('does not snapshot oversized containers that are likely the whole draft page', () => {
+  const element = fakeElement({ text: `Pick 1 ${'player '.repeat(200)}` });
+  assert.equal(snapshotPickElement(element), null);
+});
+
+test('finds Yahoo live status and last-pick banners by their visible text', () => {
+  const elements = [
+    { innerText: 'Whole page YOUR TURN • ROUND 2, PICK 19 plus lots of content' },
+    { innerText: 'YOUR TURN\n• ROUND 2, PICK 19' },
+    { innerText: 'Last:\nD. LONDON\n(WR · ATL)' },
+    { innerText: 'Last:\nD. LONDON\n(WR · ATL)\nTeam 7' },
+  ];
+  const root = { querySelectorAll: () => elements };
+
+  assert.deepEqual(findLiveDraftSnapshot(root), {
+    statusText: 'YOUR TURN\n• ROUND 2, PICK 19',
+    lastPickText: 'Last:\nD. LONDON\n(WR · ATL)\nTeam 7',
+  });
+});
+
+test('finds the last-pick banner while Yahoo is paused', () => {
+  const root = {
+    querySelectorAll: () => [
+      { innerText: 'Draft Paused' },
+      { innerText: 'Last:\nC. Olave\n(WR · NO)\nTeam 5' },
+    ],
+  };
+
+  assert.deepEqual(findLiveDraftSnapshot(root), {
+    statusText: 'Draft Paused',
+    lastPickText: 'Last:\nC. Olave\n(WR · NO)\nTeam 5',
+  });
+});
+
+test('extracts Yahoo Round by Round table rows with their round headers', () => {
+  function row(values, heading = false) {
+    const cells = values.map((textContent) => ({ textContent, innerText: textContent }));
+    return {
+      innerText: values.join('\n'),
+      querySelectorAll(selector) {
+        if (selector === 'td') return heading ? [] : cells;
+        return [];
+      },
+    };
+  }
+
+  const round3 = row(['ROUND 3'], true);
+  const olave = row(['29', 'C. Olave\nWR\nNO\nBye 8', 'Team 5']);
+  const hall = row(['28', 'B. Hall\nQ\nRB\nNYJ\nBye 13', 'Team 4']);
+  const round2 = row(['ROUND 2'], true);
+  const barkley = row(['19', 'S. Barkley\nRB\nPhi\nBye 10', 'Your Team']);
+  const table = {
+    querySelector(selector) {
+      return selector === 'thead' ? { innerText: 'Pick Player Team' } : null;
+    },
+    querySelectorAll(selector) {
+      return selector === 'tr' ? [round3, olave, hall, round2, barkley] : [];
+    },
+  };
+  const root = { querySelectorAll: (selector) => (selector === 'table' ? [table] : []) };
+
+  assert.deepEqual(findRoundByRoundSnapshots(root), [
+    {
+      roundText: 'ROUND 3',
+      pickText: '29',
+      playerText: 'C. Olave\nWR\nNO\nBye 8',
+      fantasyTeamText: 'Team 5',
+    },
+    {
+      roundText: 'ROUND 3',
+      pickText: '28',
+      playerText: 'B. Hall\nQ\nRB\nNYJ\nBye 13',
+      fantasyTeamText: 'Team 4',
+    },
+    {
+      roundText: 'ROUND 2',
+      pickText: '19',
+      playerText: 'S. Barkley\nRB\nPhi\nBye 10',
+      fantasyTeamText: 'Your Team',
+    },
+  ]);
+});
+
+test('ignores unrelated three-column tables', () => {
+  const table = {
+    querySelector: () => ({ innerText: 'Rank Player Proj' }),
+    querySelectorAll: () => [],
+  };
+  const root = { querySelectorAll: () => [table] };
+  assert.deepEqual(findRoundByRoundSnapshots(root), []);
+});
+
+test('collects sanitized football-related DOM diagnostics without URLs', () => {
+  const playerRow = {
+    tagName: 'DIV',
+    textContent: 'RB J. COOK III RB · Buf · Bye 7 Round 2 Pick 19',
+    className: 'results-row player-card',
+    childElementCount: 4,
+    getAttribute(name) {
+      return {
+        role: 'row',
+        'data-testid': 'team-result',
+        'aria-label': 'James Cook result',
+        href: 'https://example.test/?auth=secret',
+      }[name] ?? null;
+    },
+  };
+  const unrelated = { ...playerRow, textContent: 'Settings Help', className: 'footer' };
+  const root = { querySelectorAll: () => [playerRow, unrelated] };
+
+  assert.deepEqual(collectDiagnosticSnapshots(root), [
+    {
+      tag: 'div',
+      role: 'row',
+      className: 'results-row player-card',
+      testId: 'team-result',
+      ariaLabel: 'James Cook result',
+      childCount: 4,
+      text: 'RB J. COOK III RB · Buf · Bye 7 Round 2 Pick 19',
+    },
+  ]);
+});

--- a/chrome-extension/tests/draft-parser.test.js
+++ b/chrome-extension/tests/draft-parser.test.js
@@ -1,0 +1,261 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildPickKey,
+  parseDraftUrl,
+  parseLiveDraftSnapshot,
+  parsePickSnapshot,
+  parseRoundByRoundSnapshot,
+  upsertPicks,
+} = require('../draft-parser.js');
+
+test('parses a Yahoo draft URL without retaining its auth query string', () => {
+  assert.deepEqual(
+    parseDraftUrl(
+      'https://football.fantasysports.yahoo.com/draftclient/f1/12345678/6?auth=secret',
+    ),
+    {
+      sport: 'f1',
+      leagueId: '12345678',
+      teamId: '6',
+      sessionKey: 'f1:12345678',
+    },
+  );
+});
+
+test('reads a pick from explicit labels and normalizes its values', () => {
+  const pick = parsePickSnapshot({
+    text: 'Round 1 pick information',
+    labels: {
+      pickNumber: '1',
+      roundNumber: '1',
+      roundPick: '1',
+      player: '  Ja’Marr   Chase ',
+      position: 'wr',
+      nflTeam: 'cin',
+      fantasyTeam: ' Sunday Winners ',
+    },
+  });
+
+  assert.deepEqual(pick, {
+    pickNumber: 1,
+    roundNumber: 1,
+    roundPick: 1,
+    player: 'Ja’Marr Chase',
+    position: 'WR',
+    nflTeam: 'CIN',
+    fantasyTeam: 'Sunday Winners',
+  });
+});
+
+test('parses a compact Yahoo-style multiline draft row', () => {
+  const pick = parsePickSnapshot({
+    text: "7\nBijan Robinson\nATL - RB\nSunday Winners",
+  });
+
+  assert.deepEqual(pick, {
+    pickNumber: 7,
+    player: 'Bijan Robinson',
+    position: 'RB',
+    nflTeam: 'ATL',
+    fantasyTeam: 'Sunday Winners',
+  });
+});
+
+test('parses a sentence-style pick announcement', () => {
+  const pick = parsePickSnapshot({
+    text: 'Pick 15: CeeDee Lamb (DAL - WR) drafted by The Champions',
+  });
+
+  assert.deepEqual(pick, {
+    pickNumber: 15,
+    player: 'CeeDee Lamb',
+    position: 'WR',
+    nflTeam: 'DAL',
+    fantasyTeam: 'The Champions',
+  });
+});
+
+test('distinguishes a round pick from the explicitly stated overall pick', () => {
+  const pick = parsePickSnapshot({
+    text: 'Round 2, Pick 3 (15 overall): CeeDee Lamb (DAL - WR) drafted by The Champions',
+  });
+
+  assert.equal(pick.pickNumber, 15);
+  assert.equal(pick.roundNumber, 2);
+  assert.equal(pick.roundPick, 3);
+});
+
+test('parses a compact single-line result row', () => {
+  const pick = parsePickSnapshot({
+    text: '7. (7) Bijan Robinson (ATL - RB) Sunday Winners',
+  });
+
+  assert.deepEqual(pick, {
+    pickNumber: 7,
+    player: 'Bijan Robinson',
+    position: 'RB',
+    nflTeam: 'ATL',
+    fantasyTeam: 'Sunday Winners',
+  });
+});
+
+test('parses a Yahoo Round by Round results row', () => {
+  assert.deepEqual(
+    parseRoundByRoundSnapshot({
+      roundText: 'ROUND 2',
+      pickText: '19',
+      playerText: 'S. Barkley\nRB\nPhi\nBye 10',
+      fantasyTeamText: 'Your Team',
+    }),
+    {
+      pickNumber: 19,
+      roundNumber: 2,
+      player: 'S. Barkley',
+      position: 'RB',
+      nflTeam: 'PHI',
+      fantasyTeam: 'Your Team',
+      isUserPick: true,
+    },
+  );
+});
+
+test('ignores Yahoo injury markers in Round by Round player details', () => {
+  assert.deepEqual(
+    parseRoundByRoundSnapshot({
+      roundText: 'ROUND 3',
+      pickText: '28',
+      playerText: 'B. Hall\nQ\nRB\nNYJ\nBye 13',
+      fantasyTeamText: 'Team 4',
+    }),
+    {
+      pickNumber: 28,
+      roundNumber: 3,
+      player: 'B. Hall',
+      position: 'RB',
+      nflTeam: 'NYJ',
+      fantasyTeam: 'Team 4',
+      isUserPick: false,
+    },
+  );
+});
+
+test('rejects malformed Round by Round rows', () => {
+  assert.equal(parseRoundByRoundSnapshot({ pickText: 'Pick', playerText: 'Player', fantasyTeamText: 'Team' }), null);
+  assert.equal(parseRoundByRoundSnapshot({ pickText: '29', playerText: 'Loading', fantasyTeamText: 'Team 5' }), null);
+});
+
+test('parses Yahoo current-pick and last-pick banners', () => {
+  assert.deepEqual(
+    parseLiveDraftSnapshot({
+      statusText: 'YOUR TURN\n• ROUND 2, PICK 19',
+      lastPickText: 'Last:\nD. LONDON\n(WR · ATL)\nTeam 7',
+    }),
+    {
+      pickNumber: 18,
+      player: 'D. LONDON',
+      position: 'WR',
+      nflTeam: 'ATL',
+      fantasyTeam: 'Team 7',
+    },
+  );
+});
+
+test('records the last player without guessing a pick number while paused', () => {
+  assert.deepEqual(
+    parseLiveDraftSnapshot({
+      statusText: 'DRAFT PAUSED',
+      lastPickText: 'Last: C. Olave (WR · NO) Team 5',
+    }),
+    {
+      player: 'C. Olave',
+      position: 'WR',
+      nflTeam: 'NO',
+      fantasyTeam: 'Team 5',
+    },
+  );
+});
+
+test('rejects unrelated page text and incomplete rows', () => {
+  assert.equal(parsePickSnapshot({ text: 'Players Queue Chat Settings' }), null);
+  assert.equal(parsePickSnapshot({ text: '12\nDraft results are loading' }), null);
+});
+
+test('uses the overall pick as the stable key when it is available', () => {
+  assert.equal(
+    buildPickKey('f1:12345678', {
+      pickNumber: 12,
+      player: 'Amon-Ra St. Brown',
+      fantasyTeam: 'Team One',
+    }),
+    'f1:12345678:pick:12',
+  );
+});
+
+test('replaces an unnumbered live observation when its pick number becomes available', () => {
+  const existing = [{ player: 'C. Olave', fantasyTeam: 'Team 5' }];
+  const incoming = [{ pickNumber: 18, player: 'C. Olave', fantasyTeam: 'Team 5' }];
+
+  assert.deepEqual(upsertPicks('f1:12345678', existing, incoming), incoming);
+});
+
+test('collapses an existing numbered and unnumbered duplicate during migration', () => {
+  const existing = [
+    { pickNumber: 29, player: 'C. Olave', fantasyTeam: 'Team 5', roundNumber: 3 },
+    { player: 'C. OLAVE', fantasyTeam: 'Team 5', position: 'WR', nflTeam: 'NO' },
+  ];
+  const observed = [
+    { pickNumber: 29, player: 'C. Olave', fantasyTeam: 'Team 5', roundNumber: 3, position: 'WR', nflTeam: 'NO' },
+  ];
+
+  assert.deepEqual(upsertPicks('f1:12345678', existing, observed), observed);
+});
+
+test('does not duplicate a numbered ledger pick with an unnumbered live banner', () => {
+  const ledger = [{ pickNumber: 29, player: 'C. Olave', fantasyTeam: 'Team 5', roundNumber: 3 }];
+  const live = [{ player: 'C. Olave', fantasyTeam: 'Team 5', position: 'WR' }];
+
+  assert.deepEqual(upsertPicks('f1:12345678', ledger, live), [
+    { pickNumber: 29, player: 'C. Olave', fantasyTeam: 'Team 5', roundNumber: 3, position: 'WR' },
+  ]);
+});
+
+test('upserts richer observations without duplicating an existing pick', () => {
+  const existing = [
+    {
+      pickNumber: 2,
+      player: 'Justin Jefferson',
+      recordedAt: '2026-08-01T00:00:00.000Z',
+    },
+  ];
+  const incoming = [
+    {
+      pickNumber: 2,
+      player: 'Justin Jefferson',
+      position: 'WR',
+      nflTeam: 'MIN',
+      recordedAt: '2026-08-01T00:01:00.000Z',
+    },
+    {
+      pickNumber: 1,
+      player: 'Ja’Marr Chase',
+      recordedAt: '2026-08-01T00:00:30.000Z',
+    },
+  ];
+
+  assert.deepEqual(upsertPicks('f1:12345678', existing, incoming), [
+    {
+      pickNumber: 1,
+      player: 'Ja’Marr Chase',
+      recordedAt: '2026-08-01T00:00:30.000Z',
+    },
+    {
+      pickNumber: 2,
+      player: 'Justin Jefferson',
+      position: 'WR',
+      nflTeam: 'MIN',
+      recordedAt: '2026-08-01T00:00:00.000Z',
+    },
+  ]);
+});

--- a/chrome-extension/tests/export.test.js
+++ b/chrome-extension/tests/export.test.js
@@ -1,0 +1,38 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { picksToCsv, picksToJson } = require('../export.js');
+
+const picks = [
+  {
+    pickNumber: 1,
+    roundNumber: 1,
+    roundPick: 1,
+    player: 'Ja’Marr Chase',
+    position: 'WR',
+    nflTeam: 'CIN',
+    fantasyTeam: 'Winners, Inc.',
+    isUserPick: true,
+    recordedAt: '2026-08-01T00:00:00.000Z',
+  },
+];
+
+test('exports picks as spreadsheet-safe CSV', () => {
+  assert.equal(
+    picksToCsv(picks),
+    [
+      'Overall Pick,Round,Round Pick,Player,Position,NFL Team,Fantasy Team,Your Pick,Recorded At',
+      '1,1,1,Ja’Marr Chase,WR,CIN,"Winners, Inc.",true,2026-08-01T00:00:00.000Z',
+    ].join('\r\n'),
+  );
+});
+
+test('neutralizes spreadsheet formulas in CSV fields', () => {
+  const csv = picksToCsv([{ player: '=HYPERLINK("bad")', fantasyTeam: '+cmd' }]);
+  assert.match(csv, /"'=HYPERLINK\(""bad""\)"/);
+  assert.match(csv, /'\+cmd/);
+});
+
+test('exports readable JSON', () => {
+  assert.equal(picksToJson(picks), `${JSON.stringify(picks, null, 2)}\n`);
+});

--- a/chrome-extension/tests/session-store.test.js
+++ b/chrome-extension/tests/session-store.test.js
@@ -1,0 +1,52 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { updateDraftSession } = require('../session-store.js');
+
+test('creates a draft session and timestamps newly observed picks', () => {
+  const session = updateDraftSession(
+    undefined,
+    { sport: 'f1', leagueId: '12345678', teamId: '6', sessionKey: 'f1:12345678' },
+    [{ pickNumber: 1, player: 'Ja’Marr Chase' }],
+    '2026-08-01T00:00:00.000Z',
+  );
+
+  assert.deepEqual(session, {
+    sport: 'f1',
+    leagueId: '12345678',
+    teamId: '6',
+    sessionKey: 'f1:12345678',
+    picks: [
+      {
+        pickNumber: 1,
+        player: 'Ja’Marr Chase',
+        recordedAt: '2026-08-01T00:00:00.000Z',
+      },
+    ],
+    updatedAt: '2026-08-01T00:00:00.000Z',
+  });
+});
+
+test('keeps the original timestamp when a later scan enriches a pick', () => {
+  const existing = {
+    sessionKey: 'f1:12345678',
+    picks: [
+      {
+        pickNumber: 1,
+        player: 'Ja’Marr Chase',
+        recordedAt: '2026-08-01T00:00:00.000Z',
+      },
+    ],
+  };
+
+  const session = updateDraftSession(
+    existing,
+    { sport: 'f1', leagueId: '12345678', teamId: '6', sessionKey: 'f1:12345678' },
+    [{ pickNumber: 1, player: 'Ja’Marr Chase', position: 'WR' }],
+    '2026-08-01T00:01:00.000Z',
+  );
+
+  assert.equal(session.picks[0].recordedAt, '2026-08-01T00:00:00.000Z');
+  assert.equal(session.picks[0].position, 'WR');
+  assert.equal(session.updatedAt, '2026-08-01T00:01:00.000Z');
+});

--- a/chrome-extension/tests/sync-client.test.js
+++ b/chrome-extension/tests/sync-client.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { syncDraftContext } = require('../sync-client.js');
+
+test('posts agent context to the loopback MCP sync endpoint', async () => {
+  let request;
+  const result = await syncDraftContext(
+    { schemaVersion: 1, draft: { sessionKey: 'f1:123' }, picks: [] },
+    {
+      fetchImpl: async (url, options) => {
+        request = { url, options };
+        return { ok: true, json: async () => ({ status: 'ok', pickCount: 0 }) };
+      },
+    },
+  );
+
+  assert.equal(request.url, 'http://127.0.0.1:8765/draft-sync');
+  assert.equal(request.options.method, 'POST');
+  assert.equal(request.options.headers['X-Yahoo-Draft-Recorder'], '1');
+  assert.equal(JSON.parse(request.options.body).draft.sessionKey, 'f1:123');
+  assert.deepEqual(result, { status: 'ok', pickCount: 0 });
+});
+
+test('reports a useful error when the MCP server is unavailable', async () => {
+  await assert.rejects(
+    syncDraftContext(
+      { draft: { sessionKey: 'f1:123' }, picks: [] },
+      { fetchImpl: async () => { throw new Error('connection refused'); } },
+    ),
+    /connection refused/,
+  );
+});

--- a/chrome-extension/tests/webext-api.test.js
+++ b/chrome-extension/tests/webext-api.test.js
@@ -1,0 +1,74 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createWebExtensionApi } = require('../webext-api.js');
+
+test('uses Firefox promise-based browser APIs', async () => {
+  const browser = {
+    runtime: { onMessage: {} },
+    storage: {
+      local: {
+        async get(key) { return { [key]: { saved: true } }; },
+        async set(value) { return value; },
+      },
+      onChanged: {},
+    },
+    tabs: {
+      async query(query) { return [{ id: 9, query }]; },
+      async sendMessage(tabId, message) { return { tabId, message }; },
+    },
+  };
+
+  const api = createWebExtensionApi({ browser });
+  assert.deepEqual(await api.storageGet('drafts'), { drafts: { saved: true } });
+  assert.deepEqual(await api.queryTabs({ active: true }), [{ id: 9, query: { active: true } }]);
+  assert.deepEqual(await api.sendTabMessage(9, { type: 'STATUS' }), {
+    tabId: 9,
+    message: { type: 'STATUS' },
+  });
+  assert.equal(api.native, browser);
+});
+
+test('uses Chromium callback-based chrome APIs', async () => {
+  const chrome = {
+    runtime: { lastError: null, onMessage: {} },
+    storage: {
+      local: {
+        get(key, callback) { callback({ [key]: [1, 2] }); },
+        set(_value, callback) { callback(); },
+      },
+      onChanged: {},
+    },
+    tabs: {
+      query(_query, callback) { callback([{ id: 3 }]); },
+      sendMessage(_tabId, _message, callback) { callback({ ok: true }); },
+    },
+  };
+
+  const api = createWebExtensionApi({ chrome });
+  assert.deepEqual(await api.storageGet('drafts'), { drafts: [1, 2] });
+  assert.deepEqual(await api.queryTabs({ active: true }), [{ id: 3 }]);
+  assert.deepEqual(await api.sendTabMessage(3, { type: 'STATUS' }), { ok: true });
+  await api.storageSet({ drafts: [] });
+  assert.equal(api.native, chrome);
+});
+
+test('rejects callback calls when Chromium reports runtime.lastError', async () => {
+  const chrome = {
+    runtime: { lastError: null },
+    storage: { local: {}, onChanged: {} },
+    tabs: {
+      sendMessage(_tabId, _message, callback) {
+        chrome.runtime.lastError = { message: 'Receiving end does not exist' };
+        callback();
+        chrome.runtime.lastError = null;
+      },
+    },
+  };
+
+  const api = createWebExtensionApi({ chrome });
+  await assert.rejects(
+    api.sendTabMessage(3, { type: 'STATUS' }),
+    /Receiving end does not exist/,
+  );
+});

--- a/chrome-extension/webext-api.js
+++ b/chrome-extension/webext-api.js
@@ -1,0 +1,52 @@
+(function initWebExtensionApi(globalScope) {
+  'use strict';
+
+  function createWebExtensionApi(scope) {
+    const promiseNative = scope?.browser;
+    const native = promiseNative || scope?.chrome;
+    if (!native) throw new Error('WebExtension APIs are unavailable');
+
+    function callPromise(method, context, args) {
+      try {
+        return Promise.resolve(method.apply(context, args));
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    }
+
+    function callCallback(method, context, args) {
+      return new Promise((resolve, reject) => {
+        method.apply(context, [
+          ...args,
+          (result) => {
+            const lastError = native.runtime?.lastError;
+            if (lastError) reject(new Error(lastError.message || String(lastError)));
+            else resolve(result);
+          },
+        ]);
+      });
+    }
+
+    const call = promiseNative ? callPromise : callCallback;
+
+    return {
+      native,
+      storageGet(key) {
+        return call(native.storage.local.get, native.storage.local, [key]);
+      },
+      storageSet(value) {
+        return call(native.storage.local.set, native.storage.local, [value]);
+      },
+      queryTabs(query) {
+        return call(native.tabs.query, native.tabs, [query]);
+      },
+      sendTabMessage(tabId, message) {
+        return call(native.tabs.sendMessage, native.tabs, [tabId, message]);
+      },
+    };
+  }
+
+  const api = { createWebExtensionApi };
+  globalScope.YahooDraftWebExtension = api;
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/fastmcp_server.py
+++ b/fastmcp_server.py
@@ -15,8 +15,11 @@ from typing import Any, Awaitable, Callable, Dict, Literal, Optional, Sequence, 
 
 from fastmcp import Context, FastMCP
 from mcp.types import ContentBlock, TextContent
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
 
 import fantasy_football_multi_league
+from src.services.live_draft_store import LiveDraftValidationError, load_live_draft, save_live_draft
 
 # REMOVED: enhanced_mcp_tools imports - no longer using wrapper tools
 
@@ -85,6 +88,10 @@ _TOOL_PROMPTS: Dict[str, str] = {
     "ff_get_draft_results": (
         "Retrieve the draft board and pick summaries for every team in a league "
         "after the draft has completed."
+    ),
+    "ff_get_live_draft_state": (
+        "Read the latest live Yahoo draft state synced from the local browser extension. "
+        "Returns every recorded pick, all team rosters, and the user's roster."
     ),
     "ff_get_waiver_wire": (
         "List waiver-wire candidates sorted by rank, points, or trends to aid "
@@ -594,6 +601,130 @@ async def ff_clear_cache(
 )
 async def ff_get_draft_results(ctx: Context, league_key: str) -> Dict[str, Any]:
     return await _call_legacy_tool("ff_get_draft_results", ctx=ctx, league_key=league_key)
+
+
+@server.tool(
+    name="ff_get_live_draft_state",
+    description=(
+        "Read the latest live Yahoo draft board captured by the local browser extension. "
+        "Use this immediately before making next-pick recommendations. Optionally filter "
+        "by Yahoo league ID."
+    ),
+    meta=_tool_meta("ff_get_live_draft_state"),
+)
+async def ff_get_live_draft_state(
+    ctx: Context, league_id: Optional[str] = None
+) -> Dict[str, Any]:
+    try:
+        context = load_live_draft(league_id=league_id)
+    except LiveDraftValidationError as exc:
+        return {"status": "error", "message": str(exc)}
+    if context is None:
+        return {
+            "status": "not_found",
+            "message": "No live draft has been synced from the browser extension yet.",
+            "leagueId": league_id,
+        }
+    await ctx.info(
+        f"Loaded live draft {context['draft']['sessionKey']} with {len(context['picks'])} picks"
+    )
+    return {"status": "success", "liveDraft": context}
+
+
+_ALLOWED_DRAFT_SYNC_ORIGINS = (
+    "https://football.fantasysports.yahoo.com",
+    "moz-extension://",
+    "chrome-extension://",
+)
+
+
+def _is_allowed_draft_sync_origin(origin: str) -> bool:
+    return origin == _ALLOWED_DRAFT_SYNC_ORIGINS[0] or origin.startswith(
+        _ALLOWED_DRAFT_SYNC_ORIGINS[1:]
+    )
+
+
+def _draft_sync_headers(request: Request) -> Dict[str, str]:
+    origin = request.headers.get("origin", "")
+    allowed_origin = origin if _is_allowed_draft_sync_origin(origin) else ""
+    headers = {
+        "Access-Control-Allow-Headers": "Content-Type, X-Yahoo-Draft-Recorder",
+        "Access-Control-Allow-Methods": "POST, OPTIONS",
+        "Access-Control-Allow-Private-Network": "true",
+        "Vary": "Origin",
+    }
+    if allowed_origin:
+        headers["Access-Control-Allow-Origin"] = allowed_origin
+    return headers
+
+
+@server.custom_route("/draft-sync", methods=["POST", "OPTIONS"], include_in_schema=False)
+async def receive_live_draft(request: Request) -> Response:
+    """Receive private draft context only from a local Yahoo draft extension."""
+
+    headers = _draft_sync_headers(request)
+    if request.method == "OPTIONS":
+        return Response(status_code=204, headers=headers)
+
+    client_host = request.client.host if request.client else ""
+    if client_host not in {"127.0.0.1", "::1", "localhost"}:
+        return JSONResponse(
+            {"status": "error", "message": "Loopback access required"},
+            status_code=403,
+            headers=headers,
+        )
+    origin = request.headers.get("origin", "")
+    if origin and not _is_allowed_draft_sync_origin(origin):
+        return JSONResponse(
+            {"status": "error", "message": "Origin not allowed"},
+            status_code=403,
+            headers=headers,
+        )
+    if request.headers.get("x-yahoo-draft-recorder") != "1":
+        return JSONResponse(
+            {"status": "error", "message": "Recorder header required"},
+            status_code=403,
+            headers=headers,
+        )
+    try:
+        content_length = int(request.headers.get("content-length", "0") or 0)
+    except ValueError:
+        return JSONResponse(
+            {"status": "error", "message": "Invalid content length"},
+            status_code=400,
+            headers=headers,
+        )
+    if content_length > 1_000_000:
+        return JSONResponse(
+            {"status": "error", "message": "Payload too large"},
+            status_code=413,
+            headers=headers,
+        )
+
+    try:
+        body = await request.body()
+        if len(body) > 1_000_000:
+            return JSONResponse(
+                {"status": "error", "message": "Payload too large"},
+                status_code=413,
+                headers=headers,
+            )
+        payload = json.loads(body)
+        context = save_live_draft(payload)
+    except (json.JSONDecodeError, LiveDraftValidationError, ValueError, TypeError) as exc:
+        return JSONResponse(
+            {"status": "error", "message": str(exc)},
+            status_code=400,
+            headers=headers,
+        )
+    return JSONResponse(
+        {
+            "status": "ok",
+            "sessionKey": context["draft"]["sessionKey"],
+            "pickCount": len(context["picks"]),
+        },
+        headers=headers,
+    )
 
 
 @server.tool(
@@ -1710,6 +1841,7 @@ __all__ = [
     "ff_get_api_status",
     "ff_clear_cache",
     "ff_get_draft_results",
+    "ff_get_live_draft_state",
     "ff_get_waiver_wire",
     "ff_get_draft_rankings",
     "ff_get_draft_recommendation",

--- a/src/services/live_draft_store.py
+++ b/src/services/live_draft_store.py
@@ -1,0 +1,185 @@
+"""Private local storage for live draft context posted by the browser extension."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+DEFAULT_STORE_PATH = Path.home() / ".fantasy-football-mcp" / "live-drafts.json"
+MAX_PICKS = 500
+_STORE_LOCK = threading.Lock()
+_SESSION_KEY = re.compile(r"^[A-Za-z0-9_-]{1,32}:[A-Za-z0-9_-]{1,64}$")
+_PICK_STRING_FIELDS = ("player", "position", "nflTeam", "fantasyTeam", "recordedAt")
+
+
+class LiveDraftValidationError(ValueError):
+    """Raised when extension-provided draft context is invalid."""
+
+
+def _store_path(path: Optional[Union[str, Path]] = None) -> Path:
+    configured = path or os.getenv("FANTASY_FOOTBALL_LIVE_DRAFT_PATH") or DEFAULT_STORE_PATH
+    return Path(configured).expanduser()
+
+
+def _safe_string(value: Any, field: str, maximum: int = 100) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise LiveDraftValidationError(f"{field} must be a non-empty string")
+    result = value.strip()
+    if len(result) > maximum:
+        raise LiveDraftValidationError(f"{field} is too long")
+    return result
+
+
+def _safe_optional_string(value: Any, field: str, maximum: int = 100) -> Optional[str]:
+    if value is None or value == "":
+        return None
+    return _safe_string(value, field, maximum)
+
+
+def _safe_positive_integer(value: Any, field: str, maximum: int = 10000) -> Optional[int]:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1 or value > maximum:
+        raise LiveDraftValidationError(f"{field} must be a positive integer")
+    return value
+
+
+def _sanitize_pick(value: Any) -> Dict[str, Any]:
+    if not isinstance(value, dict):
+        raise LiveDraftValidationError("each pick must be an object")
+
+    pick: Dict[str, Any] = {}
+    for field, maximum in (("pickNumber", 500), ("roundNumber", 100), ("roundPick", 100)):
+        number = _safe_positive_integer(value.get(field), field, maximum)
+        if number is not None:
+            pick[field] = number
+
+    for field in _PICK_STRING_FIELDS:
+        text = _safe_optional_string(value.get(field), field)
+        if text is not None:
+            pick[field] = text
+
+    if "player" not in pick:
+        raise LiveDraftValidationError("each pick must include a player")
+    if "isUserPick" in value and not isinstance(value["isUserPick"], bool):
+        raise LiveDraftValidationError("isUserPick must be a boolean")
+    pick["isUserPick"] = (
+        value.get("isUserPick") is True
+        or pick.get("fantasyTeam", "").lower() == "your team"
+    )
+    return pick
+
+
+def sanitize_live_draft_context(value: Any) -> Dict[str, Any]:
+    """Validate and whitelist the extension payload before writing it to disk."""
+
+    if not isinstance(value, dict) or value.get("schemaVersion") != 1:
+        raise LiveDraftValidationError("schemaVersion 1 is required")
+    if value.get("source") != "yahoo-draft-recorder":
+        raise LiveDraftValidationError("unsupported draft context source")
+
+    draft = value.get("draft")
+    picks_value = value.get("picks")
+    if not isinstance(draft, dict) or not isinstance(picks_value, list):
+        raise LiveDraftValidationError("draft and picks are required")
+    if len(picks_value) > MAX_PICKS:
+        raise LiveDraftValidationError(f"draft context cannot exceed {MAX_PICKS} picks")
+
+    session_key = _safe_string(draft.get("sessionKey"), "sessionKey")
+    if not _SESSION_KEY.fullmatch(session_key):
+        raise LiveDraftValidationError("sessionKey has an invalid format")
+
+    clean_draft: Dict[str, Any] = {
+        "sport": _safe_string(draft.get("sport"), "sport", 32),
+        "leagueId": _safe_string(draft.get("leagueId"), "leagueId", 64),
+        "teamId": _safe_string(draft.get("teamId"), "teamId", 64),
+        "sessionKey": session_key,
+    }
+    updated_at = _safe_optional_string(draft.get("updatedAt"), "updatedAt")
+    if updated_at:
+        clean_draft["updatedAt"] = updated_at
+
+    picks = [_sanitize_pick(pick) for pick in picks_value]
+    picks.sort(key=lambda pick: pick.get("pickNumber", MAX_PICKS + 1))
+    user_roster = [pick for pick in picks if pick["isUserPick"]]
+    team_rosters: Dict[str, list[Dict[str, Any]]] = {}
+    for pick in picks:
+        team_rosters.setdefault(pick.get("fantasyTeam", "Unknown team"), []).append(pick)
+    numbered_picks = [pick["pickNumber"] for pick in picks if "pickNumber" in pick]
+    latest_pick = max(numbered_picks, default=0)
+
+    generated_at = _safe_optional_string(value.get("generatedAt"), "generatedAt")
+    return {
+        "schemaVersion": 1,
+        "source": "yahoo-draft-recorder",
+        "generatedAt": generated_at,
+        "draft": clean_draft,
+        "summary": {
+            "totalPicks": len(picks),
+            "latestOverallPick": latest_pick,
+            "nextOverallPick": latest_pick + 1,
+            "userPickCount": len(user_roster),
+        },
+        "userRoster": user_roster,
+        "teamRosters": team_rosters,
+        "picks": picks,
+    }
+
+
+def _read_all(path: Path) -> Dict[str, Dict[str, Any]]:
+    if not path.exists():
+        return {}
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise LiveDraftValidationError(f"could not read live draft store: {error}") from error
+    if not isinstance(value, dict):
+        raise LiveDraftValidationError("live draft store is malformed")
+    return value
+
+
+def save_live_draft(value: Any, path: Optional[Union[str, Path]] = None) -> Dict[str, Any]:
+    """Atomically save one sanitized draft session and return it."""
+
+    context = sanitize_live_draft_context(value)
+    destination = _store_path(path)
+    with _STORE_LOCK:
+        sessions = _read_all(destination)
+        sessions[context["draft"]["sessionKey"]] = context
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        handle, temporary_name = tempfile.mkstemp(
+            prefix=".live-drafts-", suffix=".json", dir=destination.parent
+        )
+        try:
+            with os.fdopen(handle, "w", encoding="utf-8") as temporary:
+                json.dump(sessions, temporary, indent=2, sort_keys=True)
+                temporary.write("\n")
+            os.chmod(temporary_name, 0o600)
+            os.replace(temporary_name, destination)
+        finally:
+            if os.path.exists(temporary_name):
+                os.unlink(temporary_name)
+    return context
+
+
+def load_live_draft(
+    league_id: Optional[str] = None, path: Optional[Union[str, Path]] = None
+) -> Optional[Dict[str, Any]]:
+    """Load the newest context, optionally restricted to one Yahoo league ID."""
+
+    with _STORE_LOCK:
+        sessions = list(_read_all(_store_path(path)).values())
+    if league_id is not None:
+        sessions = [
+            session
+            for session in sessions
+            if session.get("draft", {}).get("leagueId") == league_id
+        ]
+    if not sessions:
+        return None
+    return max(sessions, key=lambda session: str(session.get("generatedAt") or ""))

--- a/tests/test_live_draft_store.py
+++ b/tests/test_live_draft_store.py
@@ -1,0 +1,99 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from src.services.live_draft_store import (
+    LiveDraftValidationError,
+    load_live_draft,
+    save_live_draft,
+)
+
+
+def draft_context(league_id: str = "10462193") -> dict:
+    return {
+        "schemaVersion": 1,
+        "source": "yahoo-draft-recorder",
+        "generatedAt": "2026-08-31T22:45:00.000Z",
+        "draft": {
+            "sport": "f1",
+            "leagueId": league_id,
+            "teamId": "6",
+            "sessionKey": f"f1:{league_id}",
+            "updatedAt": "2026-08-31T22:44:58.255Z",
+        },
+        "summary": {
+            "totalPicks": 2,
+            "latestOverallPick": 19,
+            "nextOverallPick": 20,
+            "userPickCount": 1,
+        },
+        "userRoster": [
+            {
+                "pickNumber": 19,
+                "player": "S. Barkley",
+                "position": "RB",
+                "nflTeam": "PHI",
+                "fantasyTeam": "Your Team",
+                "isUserPick": True,
+            }
+        ],
+        "teamRosters": {},
+        "picks": [
+            {
+                "pickNumber": 1,
+                "player": "J. Gibbs",
+                "position": "RB",
+                "nflTeam": "DET",
+                "fantasyTeam": "Team 1",
+                "isUserPick": False,
+            },
+            {
+                "pickNumber": 19,
+                "roundNumber": 2,
+                "player": "S. Barkley",
+                "position": "RB",
+                "nflTeam": "PHI",
+                "fantasyTeam": "Your Team",
+                "isUserPick": True,
+            },
+        ],
+    }
+
+
+def test_saves_and_loads_latest_live_draft_context(tmp_path: Path) -> None:
+    path = tmp_path / "live-drafts.json"
+    first = draft_context("111")
+    second = draft_context("222")
+    second["generatedAt"] = "2026-08-31T22:46:00.000Z"
+
+    save_live_draft(first, path)
+    save_live_draft(second, path)
+
+    assert load_live_draft(path=path)["draft"]["leagueId"] == "222"
+    assert load_live_draft("111", path=path)["draft"]["leagueId"] == "111"
+    assert json.loads(path.read_text())["f1:222"]["summary"]["totalPicks"] == 2
+
+
+def test_strips_unknown_fields_including_credentials(tmp_path: Path) -> None:
+    context = draft_context()
+    context["auth"] = "top-secret"
+    context["draft"]["url"] = "https://example.test/?auth=top-secret"
+    context["picks"][0]["cookie"] = "top-secret"
+
+    saved = save_live_draft(context, tmp_path / "live-drafts.json")
+
+    assert "top-secret" not in json.dumps(saved)
+    assert "auth" not in saved
+    assert "url" not in saved["draft"]
+    assert "cookie" not in saved["picks"][0]
+
+
+def test_rejects_invalid_or_oversized_context(tmp_path: Path) -> None:
+    with pytest.raises(LiveDraftValidationError):
+        save_live_draft({"draft": {}, "picks": []}, tmp_path / "live-drafts.json")
+
+    context = draft_context()
+    context["picks"] = context["picks"] * 300
+    with pytest.raises(LiveDraftValidationError, match="500"):
+        save_live_draft(context, tmp_path / "live-drafts.json")


### PR DESCRIPTION
Capture complete Round-by-Round draft results in a Firefox-compatible extension and sync sanitized agent context to a loopback-only FastMCP endpoint. Add local persistence, exports, privacy safeguards, and parser coverage.